### PR TITLE
Extend Continuum trait to be more generic and decoupling with auction pallet

### DIFF
--- a/pallets/auction-manager/Cargo.toml
+++ b/pallets/auction-manager/Cargo.toml
@@ -10,11 +10,15 @@ version = '2.0.0-rc6'
 
 [dependencies]
 serde = { version = "1.0.119", optional = true }
-codec = { default-features = false, package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
-sp-std = { version = "3.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "3.0.0", default-features = false }
+sp-std = { version = "3.0.0", default-features = false }
+sp-io = { version = "3.0.0", default-features = false }
+frame-support = { version = "3.0.0", default-features = false }
 # Used for the node's RPCs
 primitives = { package = "bit-country-primitives", path = "../primitives", default-features = false }
+
+funty = { version = "=1.1.0", default-features = false }
 
 [features]
 default = ['std']
@@ -22,5 +26,7 @@ std = [
     'serde',
     'codec/std',
     'sp-runtime/std',
+    'sp-io/std',
     'sp-std/std',
+    'frame-support/std',
 ]

--- a/pallets/auction-manager/src/lib.rs
+++ b/pallets/auction-manager/src/lib.rs
@@ -1,6 +1,7 @@
 // This pallet use The Open Runtime Module Library (ORML) which is a community maintained collection of Substrate runtime modules.
 // Thanks to all contributors of orml.
 // Ref: https://github.com/open-web3-stack/open-runtime-module-library
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::FullCodec;
 use codec::{Decode, Encode};

--- a/pallets/auction/Cargo.toml
+++ b/pallets/auction/Cargo.toml
@@ -13,9 +13,10 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 serde = { version = "1.0.119", optional = true }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-std = { version = "3.0.0", default-features = false }
 sp-runtime = { version = "3.0.0", default-features = false }
+sp-io = { version = "3.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false }
 frame-system = { version = "3.0.0", default-features = false }
 
@@ -39,9 +40,6 @@ pallet-continuum = { default-features = false, package = 'pallet-continuum', pat
 auction-manager = { default-features = false, package = 'auction-manager', path = '../auction-manager' }
 
 
-[dev-dependencies]
-sp-io = { version = "3.0.0", default-features = false }
-
 [features]
 default = ['std']
 std = [
@@ -49,6 +47,7 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'sp-io/std',
     'sp-runtime/std',
     'sp-core/std',
     'pallet-balances/std',

--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -23,7 +23,7 @@ use frame_system::{self as system, ensure_signed};
 use pallet_nft::Module as NFTModule;
 use pallet_continuum::Pallet as ContinuumModule;
 
-use primitives::{ItemId, AuctionId};
+use primitives::{ItemId, AuctionId, continuum::Continuum};
 
 use auction_manager::{Auction, OnNewBidResult, AuctionHandler, Change, AuctionInfo, AuctionItem};
 use frame_support::sp_runtime::traits::AtLeast32Bit;
@@ -44,7 +44,6 @@ type BalanceOf<T> =
 pub trait Config:
 frame_system::Config
 + pallet_nft::Config
-+ pallet_continuum::Config
 {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
     type AuctionTimeToClose: Get<Self::BlockNumber>;
@@ -52,6 +51,7 @@ frame_system::Config
     type Handler: AuctionHandler<Self::AccountId, BalanceOf<Self>, Self::BlockNumber, AuctionId>;
     type Currency: ReservableCurrency<Self::AccountId>
     + LockableCurrency<Self::AccountId, Moment=Self::BlockNumber>;
+    type ContinuumHandler: Continuum<Self::AccountId>;
 
     // /// Weight information for extrinsics in this module.
     // type WeightInfo: WeightInfo;
@@ -178,7 +178,7 @@ decl_module! {
                                                     }
                                             }
                                             ItemId::Spot(spot_id, country_id) => {
-                                                let continuum_spot = ContinuumModule::<T>::transfer_spot(spot_id, &auction_item.recipient, &(high_bidder.clone(), country_id));
+                                                let continuum_spot = T::ContinuumHandler::transfer_spot(spot_id, &auction_item.recipient, &(high_bidder.clone(), country_id));
                                                 match continuum_spot{
                                                      Err(_) => continue,
                                                      Ok(_) => {

--- a/pallets/continuum/Cargo.toml
+++ b/pallets/continuum/Cargo.toml
@@ -45,9 +45,6 @@ package = 'auction-manager'
 path = '../auction-manager'
 version = '2.0.0-rc6'
 
-[dev-dependencies]
-pallet-auction = { package = 'pallet-auction', path = '../auction', version = '2.0.0-rc6' }
-
 [features]
 default = ['std']
 std = [
@@ -63,7 +60,6 @@ std = [
     'orml-tokens/std',
     'pallet_nft/std',
     'auction-manager/std',
-    'pallet-auction/std',
     'primitives/std',
     'sp-arithmetic/std',
 ]

--- a/pallets/continuum/src/lib.rs
+++ b/pallets/continuum/src/lib.rs
@@ -24,7 +24,7 @@ use frame_support::{
     traits::{Get, Vec},
 };
 use frame_system::{self as system, ensure_root, ensure_signed};
-use primitives::{Balance, CountryId, CurrencyId, SpotId, ItemId};
+use primitives::{Balance, CountryId, CurrencyId, SpotId, ItemId, continuum::Continuum};
 use sp_runtime::{traits::{AccountIdConversion, One, Zero, CheckedDiv, CheckedAdd}, DispatchError, ModuleId, RuntimeDebug, FixedPointNumber};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -522,6 +522,16 @@ impl<T: Config> Pallet<T>
     }
 
     pub fn transfer_spot(spot_id: SpotId, from: &T::AccountId, to: &(T::AccountId, CountryId)) -> Result<SpotId, DispatchError> {
+        Self::transfer_spot(spot_id, from, to)
+    }
+
+    pub fn check_approved(tally: &ContinuumSpotTally<T::AccountId>) -> bool {
+        true
+    }
+}
+
+impl<T: Config> Continuum<T::AccountId> for Pallet<T> {
+    fn transfer_spot(spot_id: SpotId, from: &T::AccountId, to: &(T::AccountId, CountryId)) -> Result<SpotId, DispatchError> {
         ContinuumSpots::<T>::try_mutate(spot_id, |maybe_spot| -> Result<SpotId, DispatchError>{
             let treasury = Self::account_id();
             if *from != treasury {
@@ -531,9 +541,5 @@ impl<T: Config> Pallet<T>
             spot.country = to.1;
             Ok(spot_id)
         })
-    }
-
-    pub fn check_approved(tally: &ContinuumSpotTally<T::AccountId>) -> bool {
-        true
     }
 }

--- a/pallets/continuum/src/types.rs
+++ b/pallets/continuum/src/types.rs
@@ -22,6 +22,8 @@ use sp_runtime::{RuntimeDebug, DispatchError};
 use sp_runtime::traits::{Zero, Bounded, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv, Saturating, One};
 use crate::{Vote, AccountVote};
 use primitives::{CountryId, SpotId};
+use sp_std::vec;
+use sp_std::vec::Vec;
 
 pub type ReferendumIndex = u64;
 

--- a/pallets/primitives/src/continuum.rs
+++ b/pallets/primitives/src/continuum.rs
@@ -1,0 +1,6 @@
+use crate::{SpotId, CountryId};
+use sp_runtime::DispatchError;
+
+pub trait Continuum<AccountId> {
+    fn transfer_spot(spot_id: SpotId, from: &AccountId, to: &(AccountId, CountryId)) -> Result<SpotId, DispatchError>;
+}

--- a/pallets/primitives/src/lib.rs
+++ b/pallets/primitives/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},
     MultiSignature,
@@ -26,6 +27,8 @@ use sp_runtime::RuntimeDebug;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
+
+pub mod continuum;
 
 /// An index to a block.
 pub type BlockNumber = u64;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -59,49 +59,13 @@ pallet-contracts-rpc-runtime-api = { version = "3.0.0", default-features = false
 oracle = { version = "1.0.0", path = "../pallets/oracle", default_features = false }
 
 primitives = { package = "bit-country-primitives", path = "../pallets/primitives", default-features = false }
-
-[dependencies.auction-manager]
-default-features = false
-package = 'auction-manager'
-path = '../pallets/auction-manager'
-version = '2.0.0-rc6'
-
-[dependencies.country]
-default-features = false
-package = 'pallet-country'
-path = '../pallets/bitcountry'
-version = '2.0.0-rc6'
-
-[dependencies.block]
-default-features = false
-package = 'pallet-block'
-path = '../pallets/block'
-version = '2.0.0-rc6'
-
-
-[dependencies.tokenization]
-default-features = false
-package = 'pallet-tokenization'
-path = '../pallets/tokenization'
-version = '2.0.0-rc6'
-
-[dependencies.nft]
-default-features = false
-package = 'pallet-nft'
-path = '../pallets/nft'
-version = '2.0.0-rc6'
-
-[dependencies.auction]
-default-features = false
-package = 'pallet-auction'
-path = '../pallets/auction'
-version = '2.0.0-rc6'
-
-[dependencies.continuum]
-default-features = false
-package = 'pallet-continuum'
-path = '../pallets/continuum'
-version = '0.0.1'
+auction-manager = { package = "auction-manager", path = "../pallets/auction-manager", version = '2.0.0-rc6', default-features = false }
+country = { package = "pallet-country", path = "../pallets/bitcountry", version = '2.0.0-rc6', default-features = false }
+block = { package = "pallet-block", path = "../pallets/block", version = '2.0.0-rc6', default-features = false }
+tokenization = { package = "pallet-tokenization", path = "../pallets/tokenization", version = '2.0.0-rc6', default-features = false }
+nft = { package = "pallet-nft", path = "../pallets/nft", version = '2.0.0-rc6', default-features = false }
+continuum = { package = "pallet-continuum", path = "../pallets/continuum", version = '0.0.1', default-features = false }
+auction = { package = "pallet-auction", path = "../pallets/auction", version = '2.0.0-rc6', default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = '4.0.0'
@@ -148,11 +112,12 @@ std = [
     'sp-transaction-pool/std',
     'sp-version/std',
     'primitives/std',
-    'auction/std',
+    'auction-manager/std',
     'orml-currencies/std',
     'orml-tokens/std',
     'orml-nft/std',
     'country/std',
+    'auction/std',
     'block/std',
     'nft/std',
     'continuum/std',
@@ -162,3 +127,9 @@ std = [
     "oracle/std"
 ]
 
+# When enabled, the runtime api will not be build.
+#
+# This is required by Cumulus to access certain types of the
+# runtime without clashing with the runtime api exported functions
+# in WASM.
+disable-runtime-api = []

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -530,6 +530,7 @@ impl auction::Config for Runtime {
     type AuctionTimeToClose = AuctionTimeToClose;
     type Handler = Auction;
     type Currency = Balances;
+    type ContinuumHandler = Continuum;
 }
 
 impl continuum::Config for Runtime {


### PR DESCRIPTION
- issue: auction pallet coupled to continuum which is not ideal for mocking, refactor continuum to handle separate transfer_spot logic
- fix no_std issues that cause duplicate lang item in crate 'std_io'