### PR TITLE
remove code that unreserves last bidder for buy now

### DIFF
--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -161,11 +161,6 @@ decl_module! {
             ensure!(<T as Config>::Currency::free_balance(&from) >= value, Error::<T>::InsufficientFunds);
 
             Self::remove_auction(auction_id.clone());
-            //Unreserve balance of last bidder
-             if let Some(current_bid) = auction.bid{
-                let (high_bidder, high_bid_price): (T::AccountId, BalanceOf<T>) = current_bid;
-                <T as Config>::Currency::unreserve(&high_bidder, high_bid_price);
-            }
             //Transfer balance from buy it now user to asset owner
             let currency_transfer = <T as Config>::Currency::transfer(&from, &auction_item.recipient, value, ExistenceRequirement::KeepAlive);
             match currency_transfer {

--- a/pallets/continuum/src/lib.rs
+++ b/pallets/continuum/src/lib.rs
@@ -32,7 +32,6 @@ use sp_std::vec;
 
 use auction_manager::{Auction, AuctionType};
 use frame_support::traits::{Currency, ReservableCurrency, LockableCurrency};
-use sp_std::vec;
 use sp_arithmetic::Perbill;
 // use crate::pallet::{Config, Pallet, ActiveAuctionSlots};
 


### PR DESCRIPTION
I am removing a block of code in the buy now function which is no longer needed since bidders cannot bid on buy now auctions there will never be a previous bidder and hence no need to unreserve the previous bidders balance.

I also removed a duplicated import in the continuum pallet.