### PR TITLE
NFT pallet unit tests + fix issue with minting assets with higher quantity than 1 (AssetIdAlreadyExist)

### DIFF
--- a/pallets/nft/Cargo.toml
+++ b/pallets/nft/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.119", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "3.0.0", default-features = false }
 sp-runtime = { version = "3.0.0", default-features = false }
+sp-io = { version = "3.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false }
 frame-system = { version = "3.0.0", default-features = false }
 primitives = { package = "bit-country-primitives", path = "../primitives", default-features = false }
@@ -35,6 +36,7 @@ std = [
     'codec/std',
     'sp-std/std',
     'sp-core/std',
+    'sp-io/std',
     'sp-runtime/std',
     'frame-support/std',
     'frame-system/std',

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -324,7 +324,7 @@ decl_module! {
                         &sender,
                         |asset_ids| -> DispatchResult {
                             // Check if the asset_id already in the owner
-                            ensure!(asset_ids.iter().any(|i| asset_id == *i), Error::<T>::AssetIdAlreadyExist);
+                            ensure!(!asset_ids.iter().any(|i| asset_id == *i), Error::<T>::AssetIdAlreadyExist);
                             asset_ids.push(asset_id);
                             Ok(())
                         }

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -76,7 +76,7 @@ fn create_group_should_work() {
 fn create_group_should_fail() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        //find way to set next collection id
+        //TODO: find way to set next collection id
     });
 }
 
@@ -242,8 +242,6 @@ fn mint_asset_should_fail() {
             vec![1],
             1
         ), Error::<Runtime>::NoPermission);
-
-        //TODO No asset id
     })
 }
 
@@ -308,8 +306,8 @@ fn transfer_batch_should_fail() {
             1
         ));
         assert_noop!(Nft::transfer_batch(origin.clone(), vec![(BOB,3),(BOB,4)]), Error::<Runtime>::AssetIdNotFound);
-        //TO DO add test case for ClassIdNotFound
-         //TO DO add test case for AssetInfoNotFound
+        //TODO add test case for ClassIdNotFound
+         //TODO add test case for AssetInfoNotFound
     })
 }
 

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -4,6 +4,9 @@ use mock::{Event, *};
 
 use primitives::{Balance};
 
+use orml_nft::Pallet as NftModule;
+use sp_std::vec::Vec;
+
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::AccountId32;
 
@@ -19,28 +22,103 @@ fn class_id_account() -> AccountId {
     <Runtime as Config>::ModuleId::get().into_sub_account(CLASS_ID)
 }
 
+fn init_test_nft(owner: Origin) {
+    assert_ok!(Nft::create_group(
+        owner.clone(),
+        vec![1],
+        vec![1],
+    ));
+    assert_ok!(Nft::create_class(
+        owner.clone(),
+        vec![1],
+        vec![1],
+        COLLECTION_ID,
+        TokenType::Transferrable,
+        CollectionType::Collectable,
+    ));
+    assert_ok!(Nft::mint(
+        owner.clone(),
+        CLASS_ID,
+        vec![1],
+        vec![1],
+        vec![1],
+        1
+    ));
+}        
+
+
+#[test]
+fn create_group_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        assert_ok!(Nft::create_group(
+            origin.clone(),
+            vec![1],
+            vec![1],
+        ));
+
+        let collection_data = NftGroupCollectionData
+        {
+            name: vec![1],
+            properties:vec![1],
+            owner: ALICE,
+        };
+
+        assert_eq!(Nft::get_group_collection(0), Some(collection_data));
+        assert_eq!(Nft::all_nft_collection_count(), 1);
+
+        let event = mock::Event::nft(RawEvent::NewNftCollectionCreated(ALICE, 0));
+        assert_eq!(last_event(), event);
+    });
+}
+
+#[test]
+fn create_group_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        //find way to set next collection id
+    });
+}
+
+
 #[test]
 fn create_class_should_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-
-        //Create group collection before class
         assert_ok!(Nft::create_group(
             origin.clone(),
             vec![1],
-            vec![1]
+            vec![1],
         ));
-
-        let event = mock::Event::nft(RawEvent::NewNftCollectionCreated(ALICE, COLLECTION_ID));
-
         assert_ok!(Nft::create_class(
-			origin.clone(),
-			vec![1],
+            origin.clone(),
+            vec![1],
             vec![1],
             COLLECTION_ID,
             TokenType::Transferrable,
             CollectionType::Collectable,
-		));
+        ));
+
+        let class_data = NftClassData
+        {
+            deposit: 2,
+            properties: vec![1],
+            token_type: TokenType::Transferrable,
+            collection_type: CollectionType::Collectable,
+            total_supply: Default::default(),
+            initial_supply: Default::default()
+        };
+
+        let class_info = orml_nft::ClassInfo::<u64, AccountId, NftClassData<u128>> {
+            metadata: vec![1],
+			total_issuance: Default::default(),
+			owner: ALICE,
+			data: class_data,
+        };
+
+        assert_eq!(Nft::get_class_collection(0), 0);
+        assert_eq!(Nft::all_nft_collection_count(), 1);
+        assert_eq!(NftModule::<Runtime>::classes(CLASS_ID), Some(class_info));
 
         let event = mock::Event::nft(RawEvent::NewNftClassCreated(ALICE, CLASS_ID));
         assert_eq!(last_event(), event);
@@ -50,4 +128,278 @@ fn create_class_should_work() {
             <Runtime as Config>::CreateClassDeposit::get()
         );
     });
+}
+
+
+#[test]
+fn create_class_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        let invalid_owner = Origin::signed(BOB);
+        assert_ok!(Nft::create_group(
+            origin.clone(),
+            vec![1],
+            vec![1],
+        ));
+
+        //collection does not exist
+        assert_noop!(Nft::create_class(
+            origin.clone(),
+            vec![1],
+            vec![1],
+            1,
+            TokenType::Transferrable,
+            CollectionType::Collectable,
+        ), Error::<Runtime>::CollectionIsNotExist);
+
+        //no permission
+        assert_noop!(Nft::create_class(
+            invalid_owner.clone(),
+            vec![1],
+            vec![1],
+            0,
+            TokenType::Transferrable,
+            CollectionType::Collectable,
+        ), Error::<Runtime>::NoPermission);
+    });
+}
+
+
+#[test]
+fn mint_asset_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+
+        init_test_nft(origin.clone());
+        
+        assert_eq!(
+            reserved_balance(&class_id_account()),
+            <Runtime as Config>::CreateClassDeposit::get() +  <Runtime as Config>::CreateAssetDeposit::get()
+        );
+        assert_eq!(Nft::next_asset_id(), 1);
+        assert_eq!(Nft::get_assets_by_owner(ALICE), vec![0]);
+        assert_eq!(Nft::get_asset(0),Some((CLASS_ID, TOKEN_ID)));
+
+        let event = mock::Event::nft(RawEvent::NewNftMinted(0, 0, ALICE, CLASS_ID, 1));
+        assert_eq!(last_event(), event);
+
+        //mint two assets
+        assert_ok!(Nft::mint(
+            origin.clone(),
+            CLASS_ID,
+            vec![1],
+            vec![1],
+            vec![1],
+            2
+        ));
+
+        assert_eq!(Nft::next_asset_id(), 3);
+        assert_eq!(Nft::get_assets_by_owner(ALICE), vec![0,1,2]);
+        assert_eq!(Nft::get_asset(1),Some((CLASS_ID, 1)));
+        assert_eq!(Nft::get_asset(2),Some((CLASS_ID, 2)));
+    })
+}
+
+#[test]
+fn mint_asset_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        let invalid_owner = Origin::signed(BOB);
+        assert_ok!(Nft::create_group(
+            origin.clone(),
+            vec![1],
+            vec![1],
+        ));
+        assert_ok!(Nft::create_class(
+            origin.clone(),
+            vec![1],
+            vec![1],
+            COLLECTION_ID,
+            TokenType::Transferrable,
+            CollectionType::Collectable,
+        ));
+        assert_noop!(Nft::mint(
+            origin.clone(),
+            CLASS_ID,
+            vec![1],
+            vec![1],
+            vec![1],
+            0
+        ), Error::<Runtime>::InvalidQuantity);
+        assert_noop!(Nft::mint(
+            origin.clone(),
+            1,
+            vec![1],
+            vec![1],
+            vec![1],
+            1
+        ), Error::<Runtime>::ClassIdNotFound);
+        assert_noop!(Nft::mint(
+            invalid_owner.clone(),
+            CLASS_ID,
+            vec![1],
+            vec![1],
+            vec![1],
+            1
+        ), Error::<Runtime>::NoPermission);
+
+        //TODO No asset id
+    })
+}
+
+
+#[test]
+fn transfer_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        init_test_nft(origin.clone());
+        assert_ok!(Nft::transfer(origin, BOB,0));
+        let event = mock::Event::nft(RawEvent::TransferedNft(1, 2, 0));
+        assert_eq!(last_event(), event);
+    })
+}
+
+#[test]
+fn transfer_batch_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        init_test_nft(origin.clone());
+        assert_ok!(Nft::create_class(
+            origin.clone(),
+            vec![1],
+            vec![1],
+            COLLECTION_ID,
+            TokenType::Transferrable,
+            CollectionType::Collectable,
+        ));
+        assert_ok!(Nft::mint(
+            origin.clone(),
+            1,
+            vec![1],
+            vec![1],
+            vec![1],
+            1
+        ));
+        assert_ok!(Nft::transfer_batch(origin, vec![(BOB,0),(BOB,1)]));
+        let event = mock::Event::nft(RawEvent::TransferedNft(1, 2, 0));
+        assert_eq!(last_event(), event);
+    })
+}
+
+#[test]
+fn transfer_batch_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {
+    let origin = Origin::signed(ALICE);
+        init_test_nft(origin.clone());
+        assert_ok!(Nft::create_class(
+            origin.clone(),
+            vec![1],
+            vec![1],
+            COLLECTION_ID,
+            TokenType::Transferrable,
+            CollectionType::Collectable,
+        ));
+        assert_ok!(Nft::mint(
+            origin.clone(),
+            1,
+            vec![1],
+            vec![1],
+            vec![1],
+            1
+        ));
+        assert_noop!(Nft::transfer_batch(origin.clone(), vec![(BOB,3),(BOB,4)]), Error::<Runtime>::AssetIdNotFound);
+        //TO DO add test case for ClassIdNotFound
+         //TO DO add test case for AssetInfoNotFound
+    })
+}
+
+#[test]
+fn do_create_group_collection_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(Nft::do_create_group_collection(&ALICE, vec![1], vec![1]));
+        let collection_data = NftGroupCollectionData
+        {
+            name: vec![1],
+            properties:vec![1],
+            owner: ALICE,
+        };
+        assert_eq!(Nft::get_group_collection(0), Some(collection_data));
+    })
+}
+
+#[test]
+fn do_handle_asset_ownership_transfer_should_work() {
+    let origin = Origin::signed(ALICE);
+    ExtBuilder::default().build().execute_with(|| {
+        init_test_nft(origin.clone());
+        assert_ok!(Nft::handle_asset_ownership_transfer(&ALICE, &BOB, 0));
+        assert_eq!(Nft::get_assets_by_owner(ALICE), Vec::<u64>::new());
+        assert_eq!(Nft::get_assets_by_owner(BOB), vec![0]);
+    })
+}
+
+#[test]
+fn do_transfer_should_work() {
+    let origin = Origin::signed(ALICE);
+    ExtBuilder::default().build().execute_with(|| {
+    init_test_nft(origin.clone());
+    assert_ok!(Nft::do_transfer(&ALICE, &BOB, 0));
+    assert_eq!(Nft::get_assets_by_owner(ALICE), Vec::<u64>::new());
+    assert_eq!(Nft::get_assets_by_owner(BOB), vec![0]);
+})
+}
+
+
+#[test]
+fn do_transfer_should_fail() {
+    let origin = Origin::signed(ALICE);
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(Nft::do_transfer(&ALICE, &BOB, 0), Error::<Runtime>::AssetIdNotFound);
+        //TODO add test for ClassIdNotFound
+
+        init_test_nft(origin.clone());
+
+        assert_noop!(Nft::do_transfer(&BOB, &ALICE, 0), Error::<Runtime>::NoPermission);
+
+        assert_ok!(Nft::create_class(
+            origin.clone(),
+            vec![1],
+            vec![1],
+            COLLECTION_ID,
+            TokenType::BoundToAddress,
+            CollectionType::Collectable,
+        ));
+        assert_ok!(Nft::mint(
+            origin.clone(),
+            1,
+            vec![1],
+            vec![1],
+            vec![1],
+            1
+        ));
+
+        assert_noop!(Nft::do_transfer(&ALICE, &BOB, 1), Error::<Runtime>::NonTransferrable);
+    })
+}
+
+
+#[test]
+fn do_check_nft_ownership_should_work() {
+    let origin = Origin::signed(ALICE);
+    ExtBuilder::default().build().execute_with(|| {
+        init_test_nft(origin.clone());
+        assert_ok!(Nft::check_nft_ownership(&ALICE, &TOKEN_ID), true);
+        assert_ok!(Nft::check_nft_ownership(&BOB, &TOKEN_ID), false);
+    })
+}
+
+
+#[test]
+fn do_check_nft_ownership_should_fail() {
+    let origin = Origin::signed(ALICE);
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(Nft::check_nft_ownership(&ALICE, &TOKEN_ID), Error::<Runtime>::AssetIdNotFound);
+        //TODO: ClassIdNotFound
+        //TODO: add test case for AssetInfoNotFound
+    })
 }


### PR DESCRIPTION
While I was testing I noticed a potential bug, we are unable to mint assets with a higher quantity than 1. 

Changed this line in lib.rs

```ensure!(asset_ids.iter().any(|i| asset_id == *i), Error::<T>::AssetIdAlreadyExist);```

to 

```ensure!(!asset_ids.iter().any(|i| asset_id == *i), Error::<T>::AssetIdAlreadyExist);```

The original logic reads, get assets by owner, if the owner has an asset with asset_id equal to the NextAssetId (which should always be false) then continue else throw an error. I believe this check should be negated so that if the user does not have an asset which matches the NextAssetId then continue else throw the error. Looking at the code with this update, I don't think this error condition will ever get triggered as we are always updating the NextAssetId on every quantity in the loop. 

Maybe we can remove this `ensure` check @justinphamnz ? Since an asset owner cannot have an asset that has an ID higher than NextAssetId as we always update the NextAssetId first on every loop.

I also had trouble testing ClassIdNotFound and AssetInfoNotFound errors thrown in the code as I needed to get the test past the AssetIdNotFound check which involves creating the Class and AssetInfo. I couldn't find a way to remove the Class and AssetInfo after they were created in the test.