### PR TITLE
add LastTokenId to NewNFTMinted event

### DIFF
--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -215,7 +215,7 @@ pub mod pallet {
         //New NFT Collection/Class created
         NewNftClassCreated(<T as frame_system::Config>::AccountId, ClassIdOf<T>),
         //Emit event when new nft minted - show the first and last asset mint
-        NewNftMinted(AssetId, AssetId, <T as frame_system::Config>::AccountId, ClassIdOf<T>, u32),
+        NewNftMinted(AssetId, AssetId, <T as frame_system::Config>::AccountId, ClassIdOf<T>, u32, TokenIdOf<T>),
         //Successfully transfer NFT
         TransferedNft(<T as frame_system::Config>::AccountId, <T as frame_system::Config>::AccountId, TokenIdOf<T>),
         //Signed on NFT
@@ -335,6 +335,7 @@ pub mod pallet {
             };
 
             let mut new_asset_ids: Vec<AssetId> = Vec::new();
+            let mut last_token_id: TokenIdOf<T> = Default::default();
 
             for _ in 0..quantity {
                 let asset_id = NextAssetId::<T>::try_mutate(|id| -> Result<AssetId, DispatchError> {
@@ -364,9 +365,10 @@ pub mod pallet {
 
                 let token_id = NftModule::<T>::mint(&sender, class_id, metadata.clone(), new_nft_data.clone())?;
                 Assets::<T>::insert(asset_id, (class_id, token_id));
+                last_token_id = token_id;
             }
 
-            Self::deposit_event(Event::<T>::NewNftMinted(*new_asset_ids.first().unwrap(), *new_asset_ids.last().unwrap(), sender, class_id, quantity));
+            Self::deposit_event(Event::<T>::NewNftMinted(*new_asset_ids.first().unwrap(), *new_asset_ids.last().unwrap(), sender, class_id, quantity, last_token_id));
 
             Ok(().into())
         }

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -142,7 +142,7 @@ fn mint_asset_should_work() {
         assert_eq!(Nft::get_assets_by_owner(ALICE), vec![0]);
         assert_eq!(Nft::get_asset(0), Some((CLASS_ID, TOKEN_ID)));
 
-        let event = mock::Event::nft(crate::Event::NewNftMinted(0, 0, ALICE, CLASS_ID, 1));
+        let event = mock::Event::nft(crate::Event::NewNftMinted(0, 0, ALICE, CLASS_ID, 1, 0));
         assert_eq!(last_event(), event);
 
         //mint two assets


### PR DESCRIPTION
We need this so that the indexer can add fetch the correct token metadata when adding to the onChainAsset collection.