### PR TITLE
New social currencies system that supports social swap and  swap LP share token

### DIFF
--- a/pallets/bitcountry/src/lib.rs
+++ b/pallets/bitcountry/src/lib.rs
@@ -20,7 +20,7 @@
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use frame_system::{ensure_root, ensure_signed};
-use primitives::{Balance, CountryId, CurrencyId};
+use primitives::{Balance, CountryId, CurrencyId, SocialTokenCurrencyId};
 use sp_runtime::{traits::{AccountIdConversion, One}, DispatchError, ModuleId, RuntimeDebug};
 use bc_country::*;
 use sp_std::vec::Vec;
@@ -214,7 +214,7 @@ impl<T: Config> Pallet<T> {
 
         let country_info = Country {
             owner: owner.clone(),
-            currency_id: Default::default(),
+            currency_id: SocialTokenCurrencyId::SocialToken(0),
             metadata,
         };
 
@@ -234,7 +234,7 @@ impl<T: Config> BCCountry<T::AccountId> for Module<T>
         Self::get_country(country_id)
     }
 
-    fn get_country_token(country_id: CountryId) -> Option<CurrencyId> {
+    fn get_country_token(country_id: CountryId) -> Option<SocialTokenCurrencyId> {
         if let Some(country) = Self::get_country(country_id) {
             return Some(country.currency_id);
         }

--- a/pallets/social-currencies/Cargo.toml
+++ b/pallets/social-currencies/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+authors = ['Bit Country <https://github.com/bit-country>']
+description = 'Bit Country pallet for tokenization logic.'
+edition = '2018'
+homepage = 'https://bit.country'
+license = 'Unlicense'
+name = 'social-currencies'
+repository = 'https://github.com/bit-country'
+version = '2.0.0-rc6'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+serde = { version = "1.0.124", optional = true }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+pallet-balances = { version = "3.0.0", default-features = false }
+frame-support = { version = "3.0.0", default-features = false }
+frame-system = { version = "3.0.0", default-features = false }
+sp-api = { version = "3.0.0", default-features = false }
+sp-io = { version = "3.0.0", default-features = false }
+sp-core = { version = "3.0.0", default-features = false }
+sp-runtime = { version = "3.0.0", default-features = false }
+sp-std = { version = "3.0.0", default-features = false }
+
+# Orml packages
+orml-traits = { default-features = false, version = '0.4.0' }
+
+primitives = { package = "bit-country-primitives", path = "../primitives", default-features = false }
+bc-country = { path = "../../traits/bc-country", default-features = false }
+
+[dependencies.country]
+default-features = false
+package = 'pallet-country'
+path = '../bitcountry'
+version = '2.0.0-rc6'
+
+[dev-dependencies]
+#sp-io = { version = "3.0.0", default-features = false }
+
+[features]
+default = ['std']
+std = [
+    'serde',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'sp-runtime/std',
+    'sp-core/std',
+    'sp-io/std',
+    'sp-std/std',
+    'orml-traits/std',
+    'primitives/std',
+    'country/std',
+]

--- a/pallets/social-currencies/src/lib.rs
+++ b/pallets/social-currencies/src/lib.rs
@@ -1,0 +1,508 @@
+// This file is part of Bit.Country.
+
+// Copyright (C) 2020-2021 Bit.Country.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::unused_unit)]
+#![allow(clippy::upper_case_acronyms)]
+
+use codec::{Decode, Encode, Codec};
+use frame_support::{
+    dispatch::{DispatchResultWithPostInfo},
+    decl_error, decl_event, decl_module, decl_storage, ensure, Parameter,
+    pallet_prelude::*,
+};
+use frame_system::{self as system, ensure_signed};
+use orml_traits::{
+    account::MergeAccount,
+    arithmetic::{Signed, SimpleArithmetic},
+    BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
+    LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency,
+};
+use primitives::{Balance, CountryId, CurrencyId, SocialTokenCurrencyId};
+use sp_runtime::{
+    traits::{CheckedSub, MaybeSerializeDeserialize, Saturating, StaticLookup, Zero},
+    DispatchError, DispatchResult,
+};
+use sp_std::{
+    convert::{TryFrom, TryInto},
+    fmt::Debug,
+    marker, result,
+    vec::Vec,
+};
+use frame_support::sp_runtime::ModuleId;
+use bc_country::*;
+use frame_support::{
+    pallet_prelude::*,
+    traits::{
+        Currency as PalletCurrency, ExistenceRequirement, Get, LockableCurrency as PalletLockableCurrency,
+        ReservableCurrency as PalletReservableCurrency, WithdrawReasons,
+    },
+};
+use frame_system::pallet_prelude::*;
+
+// #[cfg(test)]
+// mod mock;
+//
+// #[cfg(test)]
+// mod tests;
+
+pub use pallet::*;
+
+type BalanceOf<T> = <<T as Config>::MultiSocialCurrency as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
+type CurrencyIdOf<T> =
+<<T as Config>::MultiSocialCurrency as MultiCurrency<<T as frame_system::Config>::AccountId>>::CurrencyId;
+
+type AmountOf<T> =
+<<T as Config>::MultiSocialCurrency as MultiCurrencyExtended<<T as frame_system::Config>::AccountId>>::Amount;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type MultiSocialCurrency: MergeAccount<Self::AccountId>
+        + MultiCurrencyExtended<Self::AccountId, CurrencyId=SocialTokenCurrencyId>
+        + MultiLockableCurrency<Self::AccountId, CurrencyId=SocialTokenCurrencyId>
+        + MultiReservableCurrency<Self::AccountId, CurrencyId=SocialTokenCurrencyId>;
+        type NativeCurrency: BasicCurrencyExtended<Self::AccountId, Balance=BalanceOf<Self>, Amount=AmountOf<Self>>;
+        #[pallet::constant]
+        /// The native currency id
+        type GetNativeCurrencyId: Get<SocialTokenCurrencyId>;
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Transfer amount should be non-zero
+        AmountZero,
+        /// Account balance must be greater than or equal to the transfer amount
+        BalanceLow,
+        /// Account balance must be greater than or equal to the transfer amount
+        BalanceTooLow,
+        /// Balance should be non-zero
+        BalanceZero,
+        ///Insufficient balance
+        InsufficientBalance,
+        /// No permission to issue token
+        NoPermissionTokenIssuance,
+        /// Country Currency already issued for this bitcountry
+        SocialTokenAlreadyIssued,
+        /// No available next token id
+        NoAvailableTokenId,
+        //Country Is Not Available
+        CountryFundIsNotAvailable,
+        AmountIntoBalanceFailed,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::weight(10_000)]
+        pub fn transfer(
+            origin: OriginFor<T>,
+            dest: <T::Lookup as StaticLookup>::Source,
+            currency_id: CurrencyIdOf<T>,
+            #[pallet::compact] amount: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            let from = ensure_signed(origin)?;
+            let to = T::Lookup::lookup(dest)?;
+            <Self as MultiCurrency<T::AccountId>>::transfer(currency_id, &from, &to, amount)?;
+            Ok(().into())
+        }
+
+        /// Transfer some native currency to another account.
+        ///
+        /// The dispatch origin for this call must be `Signed` by the
+        /// transactor.
+        #[pallet::weight(10_000)]
+        pub fn transfer_native_currency(
+            origin: OriginFor<T>,
+            dest: <T::Lookup as StaticLookup>::Source,
+            #[pallet::compact] amount: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            let from = ensure_signed(origin)?;
+            let to = T::Lookup::lookup(dest)?;
+            T::NativeCurrency::transfer(&from, &to, amount)?;
+
+            Self::deposit_event(Event::Transferred(T::GetNativeCurrencyId::get(), from, to, amount));
+            Ok(().into())
+        }
+
+        /// update amount of account `who` under `currency_id`.
+        ///
+        /// The dispatch origin of this call must be _Root_.
+        #[pallet::weight(10_000)]
+        pub fn update_balance(
+            origin: OriginFor<T>,
+            who: <T::Lookup as StaticLookup>::Source,
+            currency_id: CurrencyIdOf<T>,
+            amount: AmountOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            ensure_root(origin)?;
+            let dest = T::Lookup::lookup(who)?;
+            <Self as MultiCurrencyExtended<T::AccountId>>::update_balance(currency_id, &dest, amount)?;
+            Ok(().into())
+        }
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub (crate) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// Currency transfer success. [currency_id, from, to, amount]
+        Transferred(CurrencyIdOf<T>, T::AccountId, T::AccountId, BalanceOf<T>),
+        /// Update balance success. [currency_id, who, amount]
+        BalanceUpdated(CurrencyIdOf<T>, T::AccountId, AmountOf<T>),
+        /// Deposit success. [currency_id, who, amount]
+        Deposited(CurrencyIdOf<T>, T::AccountId, BalanceOf<T>),
+        /// Withdraw success. [currency_id, who, amount]
+        Withdrawn(CurrencyIdOf<T>, T::AccountId, BalanceOf<T>),
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+}
+
+impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
+    type CurrencyId = CurrencyIdOf<T>;
+    type Balance = BalanceOf<T>;
+
+    fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::minimum_balance(),
+            _ => T::MultiSocialCurrency::minimum_balance(currency_id),
+        }
+    }
+
+    fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::total_issuance(),
+            _ => T::MultiSocialCurrency::total_issuance(currency_id),
+        }
+    }
+
+    fn total_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::total_balance(who),
+            _ => T::MultiSocialCurrency::total_balance(currency_id, who),
+        }
+    }
+
+    fn free_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::free_balance(who),
+            _ => T::MultiSocialCurrency::free_balance(currency_id, who),
+        }
+    }
+
+    fn ensure_can_withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::ensure_can_withdraw(who, amount),
+            _ => T::MultiSocialCurrency::ensure_can_withdraw(currency_id, who, amount),
+        }
+    }
+
+    fn transfer(
+        currency_id: Self::CurrencyId,
+        from: &T::AccountId,
+        to: &T::AccountId,
+        amount: Self::Balance,
+    ) -> DispatchResult {
+        if amount.is_zero() || from == to {
+            return Ok(());
+        }
+
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::transfer(from, to, amount)?,
+            _ => T::MultiSocialCurrency::transfer(currency_id, from, to, amount)?,
+        }
+
+        Self::deposit_event(Event::Transferred(currency_id, from.clone(), to.clone(), amount));
+        Ok(())
+    }
+
+    fn deposit(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        if amount.is_zero() {
+            return Ok(());
+        }
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::deposit(who, amount)?,
+            _ => T::MultiSocialCurrency::deposit(currency_id, who, amount)?,
+        }
+        Self::deposit_event(Event::Deposited(currency_id, who.clone(), amount));
+        Ok(())
+    }
+
+    fn withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        if amount.is_zero() {
+            return Ok(());
+        }
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::withdraw(who, amount)?,
+            _ => T::MultiSocialCurrency::withdraw(currency_id, who, amount)?,
+        }
+        Self::deposit_event(Event::Withdrawn(currency_id, who.clone(), amount));
+        Ok(())
+    }
+
+    fn can_slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> bool {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::can_slash(who, amount),
+            _ => T::MultiSocialCurrency::can_slash(currency_id, who, amount),
+        }
+    }
+
+    fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::slash(who, amount),
+            _ => T::MultiSocialCurrency::slash(currency_id, who, amount),
+        }
+    }
+}
+
+impl<T: Config> MultiCurrencyExtended<T::AccountId> for Pallet<T> {
+    type Amount = AmountOf<T>;
+
+    fn update_balance(currency_id: Self::CurrencyId, who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
+        match currency_id {
+            id if id == T::GetNativeCurrencyId::get() => T::NativeCurrency::update_balance(who, by_amount)?,
+            _ => T::MultiSocialCurrency::update_balance(currency_id, who, by_amount)?,
+        }
+        Self::deposit_event(Event::BalanceUpdated(currency_id, who.clone(), by_amount));
+        Ok(())
+    }
+}
+
+pub struct Currency<T, GetCurrencyId>(marker::PhantomData<T>, marker::PhantomData<GetCurrencyId>);
+
+impl<T, GetCurrencyId> BasicCurrency<T::AccountId> for Currency<T, GetCurrencyId>
+    where
+        T: Config,
+        GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+    type Balance = BalanceOf<T>;
+
+    fn minimum_balance() -> Self::Balance {
+        <Pallet<T>>::minimum_balance(GetCurrencyId::get())
+    }
+
+    fn total_issuance() -> Self::Balance {
+        <Pallet<T>>::total_issuance(GetCurrencyId::get())
+    }
+
+    fn total_balance(who: &T::AccountId) -> Self::Balance {
+        <Pallet<T>>::total_balance(GetCurrencyId::get(), who)
+    }
+
+    fn free_balance(who: &T::AccountId) -> Self::Balance {
+        <Pallet<T>>::free_balance(GetCurrencyId::get(), who)
+    }
+
+    fn ensure_can_withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        <Pallet<T>>::ensure_can_withdraw(GetCurrencyId::get(), who, amount)
+    }
+
+    fn transfer(from: &T::AccountId, to: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        <Pallet<T> as MultiCurrency<T::AccountId>>::transfer(GetCurrencyId::get(), from, to, amount)
+    }
+
+    fn deposit(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        <Pallet<T>>::deposit(GetCurrencyId::get(), who, amount)
+    }
+
+    fn withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+        <Pallet<T>>::withdraw(GetCurrencyId::get(), who, amount)
+    }
+
+    fn can_slash(who: &T::AccountId, amount: Self::Balance) -> bool {
+        <Pallet<T>>::can_slash(GetCurrencyId::get(), who, amount)
+    }
+
+    fn slash(who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
+        <Pallet<T>>::slash(GetCurrencyId::get(), who, amount)
+    }
+}
+
+impl<T, GetCurrencyId> BasicCurrencyExtended<T::AccountId> for Currency<T, GetCurrencyId>
+    where
+        T: Config,
+        GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+    type Amount = AmountOf<T>;
+
+    fn update_balance(who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
+        <Pallet<T> as MultiCurrencyExtended<T::AccountId>>::update_balance(GetCurrencyId::get(), who, by_amount)
+    }
+}
+
+/// Adapt other currency traits implementation to `BasicCurrency`.
+pub struct BasicCurrencyAdapter<T, Currency, Amount, Moment>(marker::PhantomData<(T, Currency, Amount, Moment)>);
+
+type PalletBalanceOf<A, Currency> = <Currency as PalletCurrency<A>>::Balance;
+
+// Adapt `frame_support::traits::Currency`
+impl<T, AccountId, Currency, Amount, Moment> BasicCurrency<AccountId>
+for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+    where
+        Currency: PalletCurrency<AccountId>,
+        T: Config,
+{
+    type Balance = PalletBalanceOf<AccountId, Currency>;
+
+    fn minimum_balance() -> Self::Balance {
+        Currency::minimum_balance()
+    }
+
+    fn total_issuance() -> Self::Balance {
+        Currency::total_issuance()
+    }
+
+    fn total_balance(who: &AccountId) -> Self::Balance {
+        Currency::total_balance(who)
+    }
+
+    fn free_balance(who: &AccountId) -> Self::Balance {
+        Currency::free_balance(who)
+    }
+
+    fn ensure_can_withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        let new_balance = Self::free_balance(who)
+            .checked_sub(&amount)
+            .ok_or(Error::<T>::BalanceTooLow)?;
+
+        Currency::ensure_can_withdraw(who, amount, WithdrawReasons::all(), new_balance)
+    }
+
+    fn transfer(from: &AccountId, to: &AccountId, amount: Self::Balance) -> DispatchResult {
+        Currency::transfer(from, to, amount, ExistenceRequirement::AllowDeath)
+    }
+
+    fn deposit(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        let _ = Currency::deposit_creating(who, amount);
+        Ok(())
+    }
+
+    fn withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        Currency::withdraw(who, amount, WithdrawReasons::all(), ExistenceRequirement::AllowDeath).map(|_| ())
+    }
+
+    fn can_slash(who: &AccountId, amount: Self::Balance) -> bool {
+        Currency::can_slash(who, amount)
+    }
+
+    fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance {
+        let (_, gap) = Currency::slash(who, amount);
+        gap
+    }
+}
+
+// Adapt `frame_support::traits::Currency`
+impl<T, AccountId, Currency, Amount, Moment> BasicCurrencyExtended<AccountId>
+for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+    where
+        Amount: Signed
+        + TryInto<PalletBalanceOf<AccountId, Currency>>
+        + TryFrom<PalletBalanceOf<AccountId, Currency>>
+        + SimpleArithmetic
+        + Codec
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug
+        + Default,
+        Currency: PalletCurrency<AccountId>,
+        T: Config,
+{
+    type Amount = Amount;
+
+    fn update_balance(who: &AccountId, by_amount: Self::Amount) -> DispatchResult {
+        let by_balance = by_amount
+            .abs()
+            .try_into()
+            .map_err(|_| Error::<T>::AmountIntoBalanceFailed)?;
+        if by_amount.is_positive() {
+            Self::deposit(who, by_balance)
+        } else {
+            Self::withdraw(who, by_balance)
+        }
+    }
+}
+
+// Adapt `frame_support::traits::LockableCurrency`
+impl<T, AccountId, Currency, Amount, Moment> BasicLockableCurrency<AccountId>
+for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+    where
+        Currency: PalletLockableCurrency<AccountId>,
+        T: Config,
+{
+    type Moment = Moment;
+
+    fn set_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        Currency::set_lock(lock_id, who, amount, WithdrawReasons::all());
+        Ok(())
+    }
+
+    fn extend_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        Currency::extend_lock(lock_id, who, amount, WithdrawReasons::all());
+        Ok(())
+    }
+
+    fn remove_lock(lock_id: LockIdentifier, who: &AccountId) -> DispatchResult {
+        Currency::remove_lock(lock_id, who);
+        Ok(())
+    }
+}
+
+// Adapt `frame_support::traits::ReservableCurrency`
+impl<T, AccountId, Currency, Amount, Moment> BasicReservableCurrency<AccountId>
+for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+    where
+        Currency: PalletReservableCurrency<AccountId>,
+        T: Config,
+{
+    fn can_reserve(who: &AccountId, value: Self::Balance) -> bool {
+        Currency::can_reserve(who, value)
+    }
+
+    fn slash_reserved(who: &AccountId, value: Self::Balance) -> Self::Balance {
+        let (_, gap) = Currency::slash_reserved(who, value);
+        gap
+    }
+
+    fn reserved_balance(who: &AccountId) -> Self::Balance {
+        Currency::reserved_balance(who)
+    }
+
+    fn reserve(who: &AccountId, value: Self::Balance) -> DispatchResult {
+        Currency::reserve(who, value)
+    }
+
+    fn unreserve(who: &AccountId, value: Self::Balance) -> Self::Balance {
+        Currency::unreserve(who, value)
+    }
+
+    fn repatriate_reserved(
+        slashed: &AccountId,
+        beneficiary: &AccountId,
+        value: Self::Balance,
+        status: BalanceStatus,
+    ) -> result::Result<Self::Balance, DispatchError> {
+        Currency::repatriate_reserved(slashed, beneficiary, value, status)
+    }
+}

--- a/pallets/social-currencies/src/mock.rs
+++ b/pallets/social-currencies/src/mock.rs
@@ -1,0 +1,189 @@
+use crate::{Module, Config};
+use crate as tokenization;
+use super::*;
+use frame_support::{
+    construct_runtime, parameter_types, ord_parameter_types, weights::Weight,
+    impl_outer_event, impl_outer_origin, impl_outer_dispatch, traits::EnsureOrigin,
+};
+use sp_core::H256;
+use sp_runtime::{testing::Header, traits::{IdentityLookup, AccountIdConversion}, ModuleId, Perbill};
+use primitives::{CurrencyId, Amount};
+use frame_system::{EnsureSignedBy, EnsureRoot};
+use frame_support::pallet_prelude::{MaybeSerializeDeserialize, Hooks, GenesisBuild};
+use frame_support::sp_runtime::traits::AtLeast32Bit;
+use orml_traits::parameter_type_with_key;
+
+pub type AccountId = u128;
+pub type AuctionId = u64;
+pub type Balance = u128;
+pub type CountryId = u64;
+pub type BlockNumber = u64;
+
+pub const ALICE: AccountId = 4;
+pub const BOB: AccountId = 5;
+pub const COUNTRY_ID: CountryId = 1;
+pub const COUNTRY_ID_NOT_EXIST: CountryId = 1;
+pub const NUUM: CurrencyId = 0;
+pub const COUNTRY_FUND: CurrencyId = 1;
+
+
+// Configure a mock runtime to test the pallet.
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: u32 = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Config for Runtime {
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Call = Call;
+    type Hash = H256;
+    type Hashing = ::sp_runtime::traits::BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type DbWeight = ();
+    type BaseCallFilter = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Config for Runtime {
+    type Balance = Balance;
+    type Event = Event;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type MaxLocks = ();
+    type WeightInfo = ();
+}
+
+parameter_type_with_key! {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+		Default::default()
+	};
+}
+
+parameter_types! {
+    pub const BitCountryTreasuryModuleId: ModuleId = ModuleId(*b"bit/trsy");
+    pub TreasuryModuleAccount: AccountId = BitCountryTreasuryModuleId::get().into_account();
+    pub const CountryFundModuleId: ModuleId = ModuleId(*b"bit/fund");
+}
+
+impl orml_tokens::Config for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type Amount = Amount;
+    type CurrencyId = CurrencyId;
+    type WeightInfo = ();
+    type ExistentialDeposits = ExistentialDeposits;
+    type OnDust = orml_tokens::TransferDust<Runtime, TreasuryModuleAccount>;
+}
+
+pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;
+
+pub struct CountryInfoSource {}
+
+impl BCCountry<AccountId> for CountryInfoSource {
+    fn check_ownership(who: &AccountId, country_id: &CountryId) -> bool {
+        match *who {
+            ALICE => true,
+            _ => false,
+        }
+    }
+
+    fn get_country(country_id: CountryId) -> Option<Country<AccountId>> {
+        None
+    }
+
+    fn get_country_token(country_id: CountryId) -> Option<CurrencyId> {
+        None
+    }
+}
+
+impl Config for Runtime {
+    type Event = Event;
+    type TokenId = u64;
+    type CountryCurrency = Currencies;
+    type SocialTokenTreasury = CountryFundModuleId;
+    type CountryInfoSource = CountryInfoSource;
+}
+
+parameter_types! {
+	pub const GetNativeCurrencyId: CurrencyId = NUUM;
+}
+
+impl orml_currencies::Config for Runtime {
+    type Event = Event;
+    type MultiCurrency = Tokens;
+    type NativeCurrency = AdaptedBasicCurrency;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type WeightInfo = ();
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},        
+        Currencies: orml_currencies::{ Module, Storage, Call, Event<T>},
+        Tokens: orml_tokens::{ Module, Storage, Call, Event<T>},
+        TokenizationModule: tokenization:: {Module, Call, Storage, Event<T>},
+	}
+);
+
+pub struct ExtBuilder;
+
+impl Default for ExtBuilder {
+    fn default() -> Self {
+        ExtBuilder
+    }
+}
+
+impl ExtBuilder {
+    pub fn build(self) -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Runtime>()
+            .unwrap();
+
+        pallet_balances::GenesisConfig::<Runtime> {
+            balances: vec![(ALICE, 100000)],
+        }
+            .assimilate_storage(&mut t)
+            .unwrap();
+
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+}
+
+pub fn last_event() -> Event {
+    frame_system::Module::<Runtime>::events()
+        .pop()
+        .expect("Event expected")
+        .event
+}

--- a/pallets/social-currencies/src/tests.rs
+++ b/pallets/social-currencies/src/tests.rs
@@ -1,0 +1,179 @@
+// Unit testing for bitcountry currency, bitcountry treasury
+#[cfg(test)]
+use super::*;
+use mock::{Event, *};
+use primitives::{Balance};
+use sp_std::vec::Vec;
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::AccountId32;
+use sp_runtime::traits::BadOrigin;
+use sp_core::blake2_256;
+
+fn country_fund_account() -> AccountId {
+    TokenizationModule::get_country_fund_id(COUNTRY_ID)
+}
+
+fn get_country_fund_balance() -> Balance {
+    match TokenizationModule::get_total_issuance(COUNTRY_ID) {
+        Ok(balance) => balance,
+        _ => 0
+    }
+}
+
+#[test]
+fn mint_social_token_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);        
+        assert_eq!(get_country_fund_balance(), 0);
+
+        assert_ok!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                400
+            )
+        );      
+
+        assert_eq!(get_country_fund_balance(), 400);
+        
+        let event = mock::Event::tokenization(
+            crate::Event::SocialTokenIssued(1, ALICE, country_fund_account(),  400)
+        );
+
+        assert_eq!(last_event(), event);
+    });
+}
+
+#[test]
+fn mint_social_token_should_fail_for_non_owner() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(BOB);
+
+        assert_noop!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                0
+            ),
+            Error::<Runtime>::NoPermissionTokenIssuance
+        );        
+    });
+}
+
+#[test]
+fn mint_social_token_should_fail_if_already_exists() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        assert_ok!(
+			TokenizationModule::mint_token(
+                origin.clone(),
+                vec![1],
+                COUNTRY_ID,
+                0
+            )
+        );        
+
+        assert_noop!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                0
+            ),
+            Error::<Runtime>::SocialTokenAlreadyIssued
+        );        
+    });
+}
+
+#[test]
+fn country_treasury_pool_withdraw_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+
+        assert_eq!(get_country_fund_balance(), 0);
+        assert_ok!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                400
+            )
+        );
+        assert_ok!(
+			Currencies::deposit(
+                COUNTRY_FUND,
+                &TokenizationModule::get_country_fund_id(COUNTRY_ID),
+                400
+            )
+        );
+        assert_eq!(get_country_fund_balance(), 800);
+        assert_ok!(
+            Currencies::withdraw(
+                COUNTRY_FUND,
+                &TokenizationModule::get_country_fund_id(COUNTRY_ID),
+                200
+            )
+        );
+        assert_eq!(get_country_fund_balance(), 600);
+    });
+}
+
+#[test]
+fn country_treasury_pool_withdraw_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        assert_eq!(get_country_fund_balance(), 0);
+        assert_ok!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                400
+            )
+        );
+        assert_eq!(get_country_fund_balance(), 400);
+        assert_noop!(
+            Currencies::withdraw(
+                COUNTRY_FUND,
+                &ALICE,
+                800
+            ),
+            orml_tokens::Error::<Runtime>::BalanceTooLow
+        );
+    });
+}
+
+#[test]
+fn country_treasury_pool_transfer_should_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        assert_eq!(get_country_fund_balance(), 0);
+        assert_ok!(
+			TokenizationModule::mint_token(
+                origin,
+                vec![1],
+                COUNTRY_ID,
+                400
+            )
+        );
+        assert_eq!(get_country_fund_balance(), 400);
+        assert_ok!(
+			Currencies::deposit(
+                COUNTRY_FUND,
+                &TokenizationModule::get_country_fund_id(COUNTRY_ID),
+                400
+            )
+        );
+        assert_ok!(
+			Currencies::transfer(
+                Origin::signed(TokenizationModule::get_country_fund_id(COUNTRY_ID)),
+                ALICE,
+                COUNTRY_FUND,
+                100
+            )
+        );
+        assert_eq!(Currencies::free_balance(COUNTRY_FUND, &ALICE), 500);
+    });
+}

--- a/runtime/bitcountry/Cargo.toml
+++ b/runtime/bitcountry/Cargo.toml
@@ -98,6 +98,7 @@ tokenization = { package = "pallet-tokenization", path = "../../pallets/tokeniza
 nft = { package = "pallet-nft", path = "../../pallets/nft", version = '2.0.0-rc6', default-features = false }
 continuum = { package = "pallet-continuum", path = "../../pallets/continuum", version = '0.0.1', default-features = false }
 auction = { package = "pallet-auction", path = "../../pallets/auction", version = '2.0.0-rc6', default-features = false }
+social-currencies = { package = "social-currencies", path = "../../pallets/social-currencies", version = '2.0.0-rc6', default-features = false }
 swap = { package = "pallet-swap", path = "../../pallets/swap", version = '2.0.0-rc6', default-features = false }
 
 [build-dependencies]
@@ -176,6 +177,7 @@ std = [
     'block/std',
     'nft/std',
     'continuum/std',
+    'social-currencies/std',
     'swap/std',
 ]
 runtime-benchmarks = [

--- a/runtime/bitcountry/src/lib.rs
+++ b/runtime/bitcountry/src/lib.rs
@@ -2,7 +2,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
-use orml_currencies::BasicCurrencyAdapter;
+use social_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
 use sp_std::prelude::*;
 use frame_support::{
@@ -28,7 +28,7 @@ use sp_core::{
     OpaqueMetadata,
 };
 pub use primitives::{AccountId, Signature};
-use primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment, CurrencyId, Amount};
+use primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment, CurrencyId, Amount, SocialTokenCurrencyId};
 use sp_api::impl_runtime_apis;
 use sp_runtime::{
     Permill, Perbill, Perquintill, Percent, ApplyExtrinsicResult,
@@ -1006,7 +1006,7 @@ impl pallet_assets::Config for Runtime {
 }
 
 parameter_type_with_key! {
-    pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+    pub ExistentialDeposits: |_currency_id: SocialTokenCurrencyId| -> Balance {
         Zero::zero()
     };
 }
@@ -1019,22 +1019,21 @@ impl orml_tokens::Config for Runtime {
     type Event = Event;
     type Balance = Balance;
     type Amount = Amount;
-    type CurrencyId = CurrencyId;
+    type CurrencyId = SocialTokenCurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
     type OnDust = orml_tokens::TransferDust<Runtime, TreasuryModuleAccount>;
 }
 
 parameter_types! {
-    pub const GetNativeCurrencyId: CurrencyId = 0;
+    pub const GetNativeCurrencyId: SocialTokenCurrencyId = SocialTokenCurrencyId::NativeToken(0);
 }
 
-impl orml_currencies::Config for Runtime {
+impl social_currencies::Config for Runtime {
     type Event = Event;
-    type MultiCurrency = Tokens;
+    type MultiSocialCurrency = Tokens;
     type NativeCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;
     type GetNativeCurrencyId = GetNativeCurrencyId;
-    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -1174,7 +1173,7 @@ construct_runtime!(
         NftModule: nft::{Module, Call, Storage, Event<T>},
         Continuum: continuum::{Module, Call, Storage, Config<T>, Event<T>},
         Auction: auction::{Module ,Storage, Event<T>},
-        Currencies: orml_currencies::{ Module, Storage, Call, Event<T>},
+        Currencies: social_currencies::{ Module, Storage, Call, Event<T>},
         Tokens: orml_tokens::{ Module, Storage, Call, Event<T>},
         TokenizationModule: tokenization:: {Module, Call, Storage, Event<T>},
         Swap: swap:: {Module, Call, Storage, Event<T>},

--- a/runtime/tewai/Cargo.toml
+++ b/runtime/tewai/Cargo.toml
@@ -92,12 +92,14 @@ orml-nft = { default-features = false, version = '0.4.0' }
 # bit.country dependencies
 # bit.country dependencies
 auction-manager = { package = "auction-manager", path = "../../traits/auction-manager", version = '2.0.0-rc6', default-features = false }
-country = { package = "pallet-country", path = "../../pallets/bitcountry", version = '2.0.0-rc6', default-features = false }
+bitcountry = { package = "pallet-country", path = "../../pallets/bitcountry", version = '2.0.0-rc6', default-features = false }
 block = { package = "pallet-block", path = "../../pallets/block", version = '2.0.0-rc6', default-features = false }
 tokenization = { package = "pallet-tokenization", path = "../../pallets/tokenization", version = '2.0.0-rc6', default-features = false }
 nft = { package = "pallet-nft", path = "../../pallets/nft", version = '2.0.0-rc6', default-features = false }
 continuum = { package = "pallet-continuum", path = "../../pallets/continuum", version = '0.0.1', default-features = false }
 auction = { package = "pallet-auction", path = "../../pallets/auction", version = '2.0.0-rc6', default-features = false }
+social-currencies = { package = "social-currencies", path = "../../pallets/social-currencies", version = '2.0.0-rc6', default-features = false }
+swap = { package = "pallet-swap", path = "../../pallets/swap", version = '2.0.0-rc6', default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = "4.0.0"
@@ -170,11 +172,13 @@ std = [
     'orml-currencies/std',
     'orml-tokens/std',
     'orml-nft/std',
-    'country/std',
+    'bitcountry/std',
     'auction/std',
     'block/std',
     'nft/std',
     'continuum/std',
+    'social-currencies/std',
+    'swap/std',
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/runtime/tewai/src/lib.rs
+++ b/runtime/tewai/src/lib.rs
@@ -2,7 +2,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
-use orml_currencies::BasicCurrencyAdapter;
+use social_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
 use sp_std::prelude::*;
 use frame_support::{
@@ -28,7 +28,7 @@ use sp_core::{
     OpaqueMetadata,
 };
 pub use primitives::{AccountId, Signature};
-use primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment, CurrencyId, Amount};
+use primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment, CurrencyId, Amount, SocialTokenCurrencyId};
 use sp_api::impl_runtime_apis;
 use sp_runtime::{
     Permill, Perbill, Perquintill, Percent, ApplyExtrinsicResult,
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 264,
+    spec_version: 265,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -353,7 +353,7 @@ impl pallet_indices::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: Balance = 1 * DOLLARS;
+	pub const ExistentialDeposit: Balance = 1 * MICROCENTS;
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;
@@ -405,6 +405,13 @@ impl pallet_authorship::Config for Runtime {
     type FilterUncle = ();
     type EventHandler = (Staking, ImOnline);
 }
+
+/// The BABE epoch configuration at genesis.
+pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =
+    sp_consensus_babe::BabeEpochConfiguration {
+        c: PRIMARY_PROBABILITY,
+        allowed_slots: sp_consensus_babe::AllowedSlots::PrimaryAndSecondaryPlainSlots,
+    };
 
 impl_opaque_keys! {
 	pub struct SessionKeys {
@@ -999,7 +1006,7 @@ impl pallet_assets::Config for Runtime {
 }
 
 parameter_type_with_key! {
-    pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+    pub ExistentialDeposits: |_currency_id: SocialTokenCurrencyId| -> Balance {
         Zero::zero()
     };
 }
@@ -1012,22 +1019,21 @@ impl orml_tokens::Config for Runtime {
     type Event = Event;
     type Balance = Balance;
     type Amount = Amount;
-    type CurrencyId = CurrencyId;
+    type CurrencyId = SocialTokenCurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
     type OnDust = orml_tokens::TransferDust<Runtime, TreasuryModuleAccount>;
 }
 
 parameter_types! {
-    pub const GetNativeCurrencyId: CurrencyId = 0;
+    pub const GetNativeCurrencyId: SocialTokenCurrencyId = SocialTokenCurrencyId::NativeToken(0);
 }
 
-impl orml_currencies::Config for Runtime {
+impl social_currencies::Config for Runtime {
     type Event = Event;
-    type MultiCurrency = Tokens;
+    type MultiSocialCurrency = Tokens;
     type NativeCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;
     type GetNativeCurrencyId = GetNativeCurrencyId;
-    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -1053,7 +1059,7 @@ impl orml_nft::Config for Runtime {
     type TokenData = nft::NftAssetData<Balance>;
 }
 
-impl country::Config for Runtime {
+impl bitcountry::Config for Runtime {
     type Event = Event;
     type ModuleId = CountryFundModuleId;
 }
@@ -1065,7 +1071,7 @@ parameter_types! {
 impl block::Config for Runtime {
     type Event = Event;
     type LandTreasury = LandTreasuryModuleId;
-    type CountryInfoSource = CountryModule;
+    type CountryInfoSource = BitCountryModule;
     type Currency = Balances;
     type MinimumLandPrice = MinimumLandPrice;
 }
@@ -1094,15 +1100,28 @@ impl continuum::Config for Runtime {
     type AuctionDuration = SpotAuctionChillingDuration;
     type ContinuumTreasury = ContinuumTreasuryModuleId;
     type Currency = Balances;
-    type CountryInfoSource = CountryModule;
+    type CountryInfoSource = BitCountryModule;
 }
 
 impl tokenization::Config for Runtime {
     type Event = Event;
     type TokenId = u64;
-    type CountryCurrency = Currencies;
+    type CountryCurrency = Tokens;
     type SocialTokenTreasury = CountryFundModuleId;
-    type CountryInfoSource = CountryModule;
+    type CountryInfoSource = BitCountryModule;
+}
+
+parameter_types! {
+    pub const SwapModuleId: ModuleId = ModuleId(*b"bit/swap");
+    pub const SwapFee: (u32, u32) = (5, 1000); //0.5%
+}
+
+impl swap::Config for Runtime {
+    type Event = Event;
+    type ModuleId = SwapModuleId;
+    type SocialTokenCurrency = Tokens;
+    type NativeCurrency = Balances;
+    type GetSwapFee = SwapFee;
 }
 
 construct_runtime!(
@@ -1148,15 +1167,16 @@ construct_runtime!(
 		Lottery: pallet_lottery::{Module, Call, Storage, Event<T>},
 
          //BitCountry pallets
-        CountryModule: country::{Module, Call, Storage, Event<T>},
+        BitCountryModule: bitcountry::{Module, Call, Storage, Event<T>},
         BlockModule: block::{Module, Call, Storage, Event<T>},
         OrmlNFT: orml_nft::{Module, Storage},
         NftModule: nft::{Module, Call, Storage, Event<T>},
         Continuum: continuum::{Module, Call, Storage, Config<T>, Event<T>},
-        Auction: auction::{Module, Call ,Storage, Event<T>},
-        Currencies: orml_currencies::{ Module, Storage, Call, Event<T>},
+        Auction: auction::{Module ,Storage, Event<T>},
+        Currencies: social_currencies::{ Module, Storage, Call, Event<T>},
         Tokens: orml_tokens::{ Module, Storage, Call, Event<T>},
         TokenizationModule: tokenization:: {Module, Call, Storage, Event<T>},
+        Swap: swap:: {Module, Call, Storage, Event<T>},
 	}
 );
 

--- a/traits/bc-country/src/lib.rs
+++ b/traits/bc-country/src/lib.rs
@@ -6,7 +6,7 @@ use sp_runtime::{
     DispatchError, DispatchResult, RuntimeDebug,
 };
 use sp_std::vec::Vec;
-use primitives::{Balance, CountryId, CurrencyId};
+use primitives::{Balance, CountryId, CurrencyId, SocialTokenCurrencyId};
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
 pub struct CountryAssetData {
@@ -17,7 +17,7 @@ pub struct CountryAssetData {
 pub struct Country<AccountId> {
     pub owner: AccountId,
     pub metadata: Vec<u8>,
-    pub currency_id: CurrencyId,
+    pub currency_id: SocialTokenCurrencyId,
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
@@ -25,7 +25,7 @@ pub struct CountryFund<AccountId, Balance> {
     pub vault: AccountId,
     pub value: Balance,
     pub backing: Balance,
-    pub currency_id: CurrencyId,
+    pub currency_id: SocialTokenCurrencyId,
 }
 
 pub trait BCCountry<AccountId> {
@@ -33,5 +33,5 @@ pub trait BCCountry<AccountId> {
 
     fn get_country(country_id: CountryId) -> Option<Country<AccountId>>;
 
-    fn get_country_token(country_id: CountryId) -> Option<CurrencyId>;
+    fn get_country_token(country_id: CountryId) -> Option<SocialTokenCurrencyId>;
 }


### PR DESCRIPTION
The new currency system for social token

- Social currency can be NativeToken, SocialToken, SwapShare (share from LP of Token Pool).
- Social currencies used orml currency traits and orml tokens trait.
- Restructure tokenization module to use social currency (unit tests need to be written).
- Implement a social currency token for LP and LP Share of Swap pool.