### PR TITLE
Fix: fail create auction when user does not own asset

### DIFF
--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -356,10 +356,12 @@ pub mod pallet {
                     let asset = NFTModule::<T>::get_asset(asset_id).ok_or(Error::<T>::AssetIsNotExist)?;
                     //Check ownership
                     let class_info = orml_nft::Pallet::<T>::classes(asset.0).ok_or(Error::<T>::NoPermissionToCreateAuction)?;
-                    ensure!(recipient == class_info.owner, Error::<T>::NoPermissionToCreateAuction);
                     let class_info_data = class_info.data;
+                    let token_info =  orml_nft::Pallet::<T>::tokens(asset.0, asset.1).ok_or(Error::<T>::NoPermissionToCreateAuction)?;
+                    ensure!(recipient == token_info.owner, Error::<T>::NoPermissionToCreateAuction);
                     ensure!(class_info_data.token_type.is_transferable(), Error::<T>::NoPermissionToCreateAuction);
                     ensure!(Self::assets_in_auction(asset_id) == None, Error::<T>::AssetAlreadyInAuction);
+
 
                     let start_time = <system::Module<T>>::block_number();
                     let end_time: T::BlockNumber = start_time + T::AuctionTimeToClose::get(); //add 7 days block for default auction

--- a/pallets/auction/src/tests.rs
+++ b/pallets/auction/src/tests.rs
@@ -309,6 +309,9 @@ fn buy_now_should_fail() {
         assert_noop!(NftAuctionModule::buy_now(buyer.clone(), 0, 150),Error::<Runtime>::AuctionNotStarted);
         System::set_block_number(101);
         assert_noop!(NftAuctionModule::buy_now(buyer.clone(), 0, 150),Error::<Runtime>::AuctionIsExpired);
+        System::set_block_number(1);
+        assert_ok!(NftAuctionModule::buy_now(buyer.clone(), 0, 150));
+        assert_noop!(NftAuctionModule::create_auction(AuctionType::BuyNow, ItemId::NFT(0), None, BOB, 150, 0),Error::<Runtime>::NoPermissionToCreateAuction);
     });
 }
 


### PR DESCRIPTION
When testing the auction flow I discovered that the asset class creator can still create an auction without actually owning the asset once it has been sold. This would happen when the asset class creator hosts an auction,  a buyer wins the auction and the asset is transferred to them but the buyer won't be able to create an auction to resell it and the asset class creator can. 

The fix: Before we create an auction we should check if the user owns the asset otherwise throw an NoPermissionToCreatAuction error.
I also removed the check that the user creating the auction has to be the asset class creator. 