### PR TITLE
Write test cases for swap pallet

### DIFF
--- a/pallets/primitives/src/dex.rs
+++ b/pallets/primitives/src/dex.rs
@@ -31,6 +31,8 @@ impl TradingPair {
     pub fn from_token_currency_ids(currency_id_0: SocialTokenCurrencyId, currency_id_1: SocialTokenCurrencyId) -> Option<Self> {
         if currency_id_0.is_native_token_currency_id() && currency_id_1.is_social_token_currency_id() {
             Some(TradingPair(currency_id_0, currency_id_1))
+        } else if currency_id_0.is_social_token_currency_id() && currency_id_1.is_native_token_currency_id() {
+            Some(TradingPair(currency_id_1, currency_id_0))
         } else {
             None
         }

--- a/pallets/primitives/src/lib.rs
+++ b/pallets/primitives/src/lib.rs
@@ -132,7 +132,7 @@ impl SocialTokenCurrencyId {
                 Some(SocialTokenCurrencyId::DEXShare(token_currency_id_0, token_currency_id_1))
             }
             (SocialTokenCurrencyId::SocialToken(token_currency_id_0), SocialTokenCurrencyId::NativeToken(token_currency_id_1)) => {
-                Some(SocialTokenCurrencyId::DEXShare(token_currency_id_0, token_currency_id_1))
+                Some(SocialTokenCurrencyId::DEXShare(token_currency_id_1, token_currency_id_0))
             }
             _ => None,
         }

--- a/pallets/swap/Cargo.toml
+++ b/pallets/swap/Cargo.toml
@@ -45,6 +45,12 @@ package = 'pallet-nft'
 path = '../nft'
 version = '2.0.0-rc6'
 
+[dev-dependencies.social-currencies]
+default-features = false
+package = "social-currencies" 
+path = "../social-currencies"
+version = '2.0.0-rc6'
+
 [features]
 default = ['std']
 std = [

--- a/pallets/swap/src/lib.rs
+++ b/pallets/swap/src/lib.rs
@@ -493,7 +493,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // Transfer out the social token
-        T::SocialTokenCurrency::transfer(target_currency, &dex_module_account_id, who, amount_in)?;
+        T::SocialTokenCurrency::transfer(target_currency, &dex_module_account_id, who, social_token_out)?;
 
         Self::deposit_event(
             Event::Swap(

--- a/pallets/swap/src/tests.rs
+++ b/pallets/swap/src/tests.rs
@@ -20,159 +20,260 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok};
 use mock::{Event, *};
-use sp_core::blake2_256;
-use sp_runtime::traits::BadOrigin;
 
 #[test]
-fn create_bc_should_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_eq!(
-            CountryModule::get_country(&COUNTRY_ID),
-            Some(Country {
-                owner: ALICE,
-                metadata: vec![1],
-                currency_id: Default::default(),
-            })
+fn add_liquidity_should_fail_with_invalid_pair() {
+    ExtBuilder::default().build().execute_with(|| {        
+        // As written code requires NUUM_SOC begins w/ native token (NUUM)
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), SOC, SOC_2, 10, 10),
+            Error::<Runtime>::InvalidSocialTokenIds
         );
-        let event = Event::bitcountry(crate::Event::NewCountryCreated(COUNTRY_ID));
-        assert_eq!(last_event(), event);
+        // assert_noop!(
+        //     SwapModule::add_liquidity(ALICE.into(), SOC, NUUM, 10, 10),
+        //     Error::<Runtime>::InvalidSocialTokenIds
+        // );
+        // TODO - test NUUM_SOC not enabled
     });
 }
 
 #[test]
-fn create_bc_should_fail() {
-    ExtBuilder::default().build().execute_with(|| {
+fn add_liquidity_should_fail_with_insufficient_balances() {
+    ExtBuilder::default().build().execute_with(|| {      
+        // NUUM balance too low
         assert_noop!(
-            CountryModule::create_bc(Origin::none(), vec![1],),
-            BadOrigin
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 1000, 10),
+            pallet_balances::Error::<Runtime>::InsufficientBalance
+        );
+        // SOC balance too low
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 10, 1000),
+            orml_tokens::Error::<Runtime>::BalanceTooLow
+        );
+        // Below existential deposit
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 100, 10),
+            pallet_balances::Error::<Runtime>::KeepAlive
+        );
+    });
+}
+        
+#[test]
+fn add_liquidity_should_not_work_with_zero_liquidity_increment() {
+    ExtBuilder::default().build().execute_with(|| {      
+        // Invalid Liquidity Increment
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 0, 10),
+            Error::<Runtime>::InvalidLiquidityIncrement
+        );
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 10, 0),
+            Error::<Runtime>::InvalidLiquidityIncrement
+        );
+        assert_noop!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 0, 0),
+            Error::<Runtime>::InvalidLiquidityIncrement
         );
     });
 }
 
 #[test]
-fn transfer_country_should_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_ok!(CountryModule::transfer_country(
-            Origin::signed(ALICE),
-            BOB,
-            COUNTRY_ID
-        ));
-        let event = Event::bitcountry(crate::Event::TransferredCountry(COUNTRY_ID, ALICE, BOB));
-        assert_eq!(last_event(), event);
-        //Make sure 2 ways transfer works
-        assert_ok!(CountryModule::transfer_country(
-            Origin::signed(BOB),
-            ALICE,
-            COUNTRY_ID
-        ));
-        let event = Event::bitcountry(crate::Event::TransferredCountry(COUNTRY_ID, BOB, ALICE));
-        assert_eq!(last_event(), event);
-    })
-}
-
-#[test]
-fn transfer_country_should_fail() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_noop!(
-            CountryModule::transfer_country(Origin::signed(BOB), ALICE, COUNTRY_ID),
-            Error::<Runtime>::NoPermission
+fn add_liquidity_should_work_with_greater_max_native_amount() {
+    ExtBuilder::default().build().execute_with(|| {    
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 10, 5));
+    
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &ALICE), 90); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &ALICE), 95); 
+        assert_eq!(SocialCurrencies::total_balance(SHARE, &ALICE), 20); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &DEX), 10); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &DEX), 5); 
+        
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (10, 5));
+        let event = mock::Event::swap(
+            crate::Event::AddLiquidity(ALICE, NUUM_SOC.0, 10, NUUM_SOC.1, 5, 20)
         );
-    })
+        assert_eq!(last_event(), event);    
+    });
 }
 
 #[test]
-fn freeze_country_should_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_ok!(CountryModule::freeze_country(Origin::root(), COUNTRY_ID));
-        let event = Event::bitcountry(crate::Event::CountryFreezed(COUNTRY_ID));
-        assert_eq!(last_event(), event);
-    })
-}
-
-#[test]
-fn freeze_country_should_fail() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        //Country owner tries to freeze their own bitcountry
-        assert_noop!(
-            CountryModule::freeze_country(Origin::signed(ALICE), COUNTRY_ID),
-            BadOrigin
+fn add_liquidity_should_work_with_greater_max_social_amount() {
+    ExtBuilder::default().build().execute_with(|| {            
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 5, 10));
+    
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &ALICE), 95); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &ALICE), 90); 
+        assert_eq!(SocialCurrencies::total_balance(SHARE, &ALICE), 20); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &DEX), 5); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &DEX), 10); 
+        
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (5, 10));
+        let event = mock::Event::swap(
+            crate::Event::AddLiquidity(ALICE, NUUM_SOC.0, 5, NUUM_SOC.1, 10, 20)
         );
-    })
+        assert_eq!(last_event(), event);    
+    });
 }
 
 #[test]
-fn unfreeze_country_should_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_ok!(CountryModule::freeze_country(Origin::root(), COUNTRY_ID));
-        let event = Event::bitcountry(crate::Event::CountryFreezed(COUNTRY_ID));
-        assert_eq!(last_event(), event);
-        assert_ok!(CountryModule::unfreeze_country(Origin::root(), COUNTRY_ID));
-        let event = Event::bitcountry(crate::Event::CountryUnFreezed(COUNTRY_ID));
-        assert_eq!(last_event(), event);
-    })
-}
-
-#[test]
-fn destroy_country_should_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_ok!(CountryModule::destroy_country(Origin::root(), COUNTRY_ID));
-        let event = Event::bitcountry(crate::Event::CountryDestroyed(COUNTRY_ID));
-        assert_eq!(last_event(), event);
-    })
-}
-
-#[test]
-fn destroy_country_without_root_should_fail() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
-        assert_noop!(
-            CountryModule::destroy_country(Origin::signed(ALICE), COUNTRY_ID),
-            BadOrigin
+fn add_liquidity_should_work_when_share_issuance_greater_than_zero() {
+    ExtBuilder::default().build().execute_with(|| {                            
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 5, 5));            
+        let event = mock::Event::swap(
+            crate::Event::AddLiquidity(ALICE, NUUM_SOC.0, 5, NUUM_SOC.1, 5, 10)
         );
-    })
+        assert_eq!(last_event(), event);    
+
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 5, 5));            
+        let event = mock::Event::swap(
+            crate::Event::AddLiquidity(ALICE, NUUM_SOC.0, 5, NUUM_SOC.1, 5, 10)
+        );
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (10, 10));        
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &ALICE), 90); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &ALICE), 90); 
+        assert_eq!(SocialCurrencies::total_balance(SHARE, &ALICE), 20); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &DEX), 10); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &DEX), 10); 
+        assert_eq!(last_event(), event);    
+    });
 }
 
 #[test]
-fn destroy_country_with_no_id_should_fail() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert_ok!(CountryModule::create_bc(
-            Origin::signed(ALICE),
-            vec![1]
-        ));
+fn remove_liquidity_should_fail_with_invalid_pair() {
+    ExtBuilder::default().build().execute_with(|| {        
+        // As written code requires NUUM_SOC begins w/ native token (NUUM)
         assert_noop!(
-            CountryModule::destroy_country(Origin::root(), COUNTRY_ID_NOT_EXIST),
-            Error::<Runtime>::CountryInfoNotFound
+            SwapModule::remove_liquidity(ALICE.into(), SOC, SOC_2, 10),
+            Error::<Runtime>::InvalidSocialTokenIds
         );
-    })
+        // assert_noop!(
+        //     SwapModule::remove_liquidity(ALICE.into(), SOC, NUUM, 10),
+        //     Error::<Runtime>::InvalidSocialTokenIds
+        // );
+        // TODO - Test NUUM_SOC not enabled        
+    });
+}
+
+#[test]
+fn remove_liquidity_should_fail_with_insufficient_balances () {
+    ExtBuilder::default().build().execute_with(|| {                
+        assert_ok!(
+            SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 1, 1)
+        );            
+
+        // ALICE attempts to take more shares than she owns:
+        assert_noop!(
+            SwapModule::remove_liquidity(ALICE.into(), NUUM, SOC, 10),
+            orml_tokens::Error::<Runtime>::BalanceTooLow
+        );        
+        // ALICE's drops dex account below existential deposit
+        assert_noop!(
+            SwapModule::remove_liquidity(ALICE.into(), NUUM, SOC, 2),
+            pallet_balances::Error::<Runtime>::KeepAlive
+        );
+        // Make sure state unchanged
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (1, 1));        
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &ALICE), 99); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &ALICE), 99); 
+        assert_eq!(SocialCurrencies::total_balance(SHARE, &ALICE), 2); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.0, &DEX), 1); 
+        assert_eq!(SocialCurrencies::total_balance(NUUM_SOC.1, &DEX), 1);        
+    });
+}
+
+#[test]
+fn remove_liquidity_should_work() {
+    ExtBuilder::default().build().execute_with(|| {                        
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM_SOC.0, NUUM_SOC.1, 10, 5));
+        assert_ok!(SwapModule::add_liquidity(BOB.into(), NUUM_SOC.0, NUUM_SOC.1, 50, 20));            
+
+        let event = mock::Event::swap(
+            crate::Event::RemoveLiquidity(ALICE, NUUM_SOC.0, 2, NUUM_SOC.1, 1, 5)
+        );
+        
+        assert_ok!(SwapModule::remove_liquidity(ALICE.into(), NUUM, SOC, 5));
+        assert_eq!(last_event(), event);                ;                  
+    });
+}
+
+#[test]
+fn swap_native_token_with_exact_supply_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {                        
+        assert_noop!(
+            SwapModule::swap_native_token_with_exact_supply(ALICE.into(), SOC, NUUM, 1, 1),
+            Error::<Runtime>::InvalidTradingCurrency
+        );
+
+        assert_noop!(
+            SwapModule::swap_native_token_with_exact_supply(ALICE.into(), NUUM, SOC, 1, 1),
+            Error::<Runtime>::InsufficientLiquidity
+        );
+
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 50, 50));        
+
+        assert_noop!(
+            SwapModule::swap_native_token_with_exact_supply(ALICE.into(), NUUM, SOC, 5, 10),
+            Error::<Runtime>::InsufficientTargetAmount
+        );        
+        // TODO - Test NUUM_SOC not enabled 
+    });
+}
+
+#[test]
+fn swap_native_token_with_exact_supply_should_work() {
+    ExtBuilder::default().build().execute_with(|| {                        
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 50, 50));
+
+        assert_ok!(SwapModule::swap_native_token_with_exact_supply(BOB.into(), NUUM, SOC, 10, 7));
+        let event = mock::Event::swap(
+            crate::Event::Swap(BOB, vec![NUUM, SOC], 10, 7)
+        );
+
+        assert_eq!(last_event(), event);
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (60, 43));        
+        assert_eq!(SocialCurrencies::total_balance(NUUM, &BOB), 90); 
+        assert_eq!(SocialCurrencies::total_balance(SOC, &BOB), 107); 
+    });
+}
+
+#[test]
+fn swap_social_token_with_exact_native_token_should_fail() {
+    ExtBuilder::default().build().execute_with(|| {                        
+        assert_noop!(
+            SwapModule::swap_social_token_with_exact_native_token(ALICE.into(), NUUM, SOC, 1, 1),
+            Error::<Runtime>::InvalidTradingCurrency
+        );
+
+        assert_noop!(
+            SwapModule::swap_social_token_with_exact_native_token(ALICE.into(), SOC, NUUM, 1, 1),
+            Error::<Runtime>::InsufficientLiquidity
+        );
+
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 50, 50));        
+            
+        assert_noop!(
+            SwapModule::swap_social_token_with_exact_native_token(ALICE.into(), SOC, NUUM, 10, 5),
+            Error::<Runtime>::TooMuchSupplyAmount
+        );        
+    });
+}
+
+#[test]
+fn swap_social_token_with_exact_native_token_should_work() {
+    ExtBuilder::default().build().execute_with(|| {                        
+        assert_ok!(SwapModule::add_liquidity(ALICE.into(), NUUM, SOC, 50, 50));
+
+        assert_ok!(
+            SwapModule::swap_social_token_with_exact_native_token(BOB.into(), SOC, NUUM, 7, 10)
+        );
+        
+        let event = mock::Event::swap(
+            crate::Event::Swap(BOB, vec![SOC, NUUM], 9, 7)
+        );
+
+        assert_eq!(last_event(), event);
+        assert_eq!(SwapModule::liquidity_pool(NUUM_SOC), (43, 59));        
+        assert_eq!(SocialCurrencies::total_balance(NUUM, &BOB), 107);         
+        assert_eq!(SocialCurrencies::total_balance(SOC, &BOB), 91);         
+    });
 }


### PR DESCRIPTION
Noticed a couple of issues having to do with pair ordering. Made changes so that `TradingPairs` are created with uniform ordering (native currency first, social second) regardless of which order they are provided to create functions. 