### PR TITLE
Bit.Country local governance update

### DIFF
--- a/metadataType.json
+++ b/metadataType.json
@@ -165,5 +165,73 @@
     "currency_id": "SocialTokenCurrencyId"
   },
   "LandId": "u64",
-  "TokenId": "u64"
+  "TokenId": "u64",
+  "PreimageStatus": {
+    "_enum": {
+      "Missing": "BlockNumber",
+      "Available": {
+        "data": "Vec<u8>", 
+        "provider": "AccountId", 
+        "deposit": "Balance",
+        "since": "BlockNumber", 
+        "expiry": "Option<BlockNumber>"
+      }
+    }
+  },
+  "VoteThreshold": {
+    "_enum": [
+      "StandardQualifiedMajority",
+      "TwoThirdsSupermajority",
+      "ThreeFifthsSupermajority",
+      "ReinforcedQualifiedMajority",
+      "RelativeMajority"
+    ]
+  },
+  "ProposalId": "u64",
+  "CountryParameter": {
+    "_enum": {
+      "MaxProposals": "u8",
+      "SetReferendumJury": "AccountId"
+    }
+  },
+  "ReferendumParameters": {
+    "voting_threshold": "Option<VoteThreshold>",
+    "min_proposal_launch_period": "BlockNumber",
+    "voting_period": "BlockNumber",
+    "enactment_period": "BlockNumber",
+    "max_proposals_per_country": "u8"
+  },
+  "Vote": {
+    "aye": "bool"
+  },
+  "Tally": {
+    "ayes": "u32",
+    "nays": "u32",
+    "turnout": "u32"
+  },
+  "VotingRecord": {
+    "votes": "Vec<(ReferendumId,Vote)>"
+  },
+  "ProposalInfo": {
+    "proposed_by": "AccountId",
+    "hash": "Hash",
+    "description": "Vec<u8>",
+    "referendum_launch_block": "BlockNumber"
+  },
+  "ReferendumStatus": {
+    "end": "BlockNumber",
+    "country": "CountryId",
+    "proposal": "ProposalId",
+    "tally": "Tally",
+    "threshold": "Option<VoteThreshold>"
+  },
+  "ReferendumInfo": {
+    "_enum": {
+      "Ongoing": "ReferendumStatus",
+      "Finished": {
+        "passed": "bool",
+        "end": "BlockNumber"
+      }
+    }
+  }
 }

--- a/pallets/governance/src/lib.rs
+++ b/pallets/governance/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
-//use codec::{Decode, Encode};
+use codec::{Decode, Encode, Input};
 
 use frame_system::ensure_signed;
 use primitives::{CountryId, ProposalId, ReferendumId};
@@ -458,7 +458,7 @@ pub mod pallet {
             }
         }
          
-     /*    fn pre_image_data_len(proposal_hash: T::Hash) -> Result<u32, DispatchError> {
+     fn pre_image_data_len(proposal_hash: T::Hash) -> Result<u32, DispatchError> {
             // To decode the `data` field of Available variant we need:
             // * one byte for the variant
             // * at most 5 bytes to decode a `Compact<u32>`
@@ -487,7 +487,7 @@ pub mod pallet {
                 .0;
     
             Ok(len)
-        } */
+        } 
 
         fn update_proposals_per_country_number(country: CountryId, is_proposal_added: bool) -> DispatchResult {
             <TotalProposalsPerCountry<T>>::try_mutate(country, |number_of_proposals| -> DispatchResult {
@@ -501,7 +501,6 @@ pub mod pallet {
             })
         }
 
-         // TO DO: Check proposal hash instead of parameter
         fn does_proposal_changes_jury(referendum_status: ReferendumStatus<T::BlockNumber>) -> Result<bool, DispatchError> {
             let proposal_hash = Self::proposals(referendum_status.country,referendum_status.proposal).ok_or(Error::<T>::ProposalDoesNotExist)?.hash;
             let preimage_status = Self::preimages(proposal_hash).ok_or(Error::<T>::PreimageMissing)?;
@@ -623,57 +622,6 @@ pub mod pallet {
                 Self::deposit_event(Event::<T>::PreimageMissing(country, proposal_info.hash, proposal_id));
                 Err(Error::<T>::PreimageMissing.into())
             }
-            
-
-            // parameters implementation
-            /*
-            let proposal_parameters = proposal_info.parameters;
-            let mut are_referendum_params_updated = false;
-            let mut new_referendum_parameters: ReferendumParameters<T::BlockNumber>;
-            match Self::referendum_parameters(country) {
-                Some(current_params) => new_referendum_parameters = current_params,
-                None =>  {
-                        new_referendum_parameters = ReferendumParameters {
-                        voting_threshold: Some(VoteThreshold::RelativeMajority),
-                        min_proposal_launch_period: T::DefaultProposalLaunchPeriod::get(),
-                        voting_period: T::DefaultVotingPeriod::get(),
-                        enactment_period: T::DefaultEnactmentPeriod::get(),
-                        max_params_per_proposal: T::DefaultMaxParametersPerProposal::get(),
-                        max_proposals_per_country: T::DefaultMaxProposalsPerCountry::get()
-                    };
-                    are_referendum_params_updated = true;
-                }
-            };
-           
-            for parameter in proposal_parameters.iter() {
-                match parameter {
-                    CountryParameter::MaxProposals(new_max_proposals) => {
-                        new_referendum_parameters.max_proposals_per_country = *new_max_proposals;
-                        are_referendum_params_updated = true;
-                    },
-                    CountryParameter::MaxParametersPerProposal(new_max_params) => {
-                        new_referendum_parameters.max_params_per_proposal = *new_max_params;
-                        are_referendum_params_updated = true;
-                     },
-                    CountryParameter::SetReferendumJury(new_jury_address) => {
-                        // TO DO: Finish Implementation
-                        //  <ReferendumJuryOf<T>>::try_mutate(country,|jury| -> DispatchResult {
-                           // let new_acc: AccountId = T::AccountId::decode(new_jury_address.as_mut()).expect("error");
-                           // *jury = Some(new_acc);
-                            // Ok(())
-                      //  });
-                    },//),
-                    _ => {}, // implement more options when new parameters are included
-                }
-            }
-            if are_referendum_params_updated  {
-                <ReferendumParametersOf<T>>::try_mutate(country,|referendum_params| -> DispatchResult {
-                    *referendum_params = Some(new_referendum_parameters);
-                    Ok(())
-                });
-            }
-            Ok(())
-             */
         }
 
     }

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 
 use sp_core::H256;
-use sp_runtime::{Perbill, testing::Header, traits::IdentityLookup};
+use sp_runtime::{Perbill, testing::Header, traits::{IdentityLookup,Hash, BlakeTwo256}};
 use primitives::SocialTokenCurrencyId;
 use bc_country::Country;
 use frame_support::{pallet_prelude::Hooks, weights::Weight};
@@ -213,4 +213,12 @@ pub fn run_to_block(n: u64) {
     while System::block_number() < n {
         next_block();
     }
+}
+
+fn set_balance_proposal(value: u64) -> Vec<u8> {
+	Call::Balances(pallet_balances::Call::set_balance(42, value, 0)).encode()
+}
+
+pub fn set_balance_proposal_hash(value: u64) -> H256 {
+    BlakeTwo256::hash(&set_balance_proposal(value)[..])
 }

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -30,13 +30,12 @@ pub const BOB: AccountId = 2;
 pub const ALICE_COUNTRY_ID: CountryId = 1;
 pub const BOB_COUNTRY_ID: CountryId = 2;
 pub const PROPOSAL_DESCRIPTION: [u8;2] = [1,2];
-pub const PROPOSAL_PARAMETERS: [CountryParameter;2] = [CountryParameter::MaxProposals(2), CountryParameter::MaxParametersPerProposal(2)];
+//pub const PROPOSAL_PARAMETER: CountryParameter = CountryParameter::MaxParametersPerProposal(2);
 pub const REFERENDUM_PARAMETERS: ReferendumParameters<BlockNumber> = ReferendumParameters {
     voting_threshold: Some(VoteThreshold::RelativeMajority),
     min_proposal_launch_period: 12,
     voting_period:5, 
     enactment_period: 10, 
-    max_params_per_proposal: 2,
     max_proposals_per_country: 1,
 };  
 
@@ -215,8 +214,8 @@ pub fn run_to_block(n: u64) {
     }
 }
 
-fn set_balance_proposal(value: u64) -> Vec<u8> {
-	Call::Balances(pallet_balances::Call::set_balance(42, value, 0)).encode()
+pub fn set_balance_proposal(value: u64) -> Vec<u8> {
+	Call::Balances(pallet_balances::Call::set_balance(BOB, value, 100)).encode()
 }
 
 pub fn set_balance_proposal_hash(value: u64) -> H256 {

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -129,6 +129,7 @@ parameter_types! {
     pub const DefaultMaxProposalsPerCountry: u8 = 2;
     pub const OneBlock: BlockNumber = 1;
     pub const MinimumProposalDeposit: Balance = 50;
+    pub const DefaultPreimageByteDeposit: Balance = 1;
 }
 
 impl Config for Runtime {
@@ -138,6 +139,7 @@ impl Config for Runtime {
     type DefaultProposalLaunchPeriod = DefaultProposalLaunchPeriod;
     type DefaultMaxParametersPerProposal =  DefaultMaxParametersPerProposal;
     type DefaultMaxProposalsPerCountry = DefaultMaxProposalsPerCountry;
+    type DefaultPreimageByteDeposit = DefaultPreimageByteDeposit;
     type MinimumProposalDeposit = MinimumProposalDeposit;
     type OneBlock = OneBlock;
     type Currency = Balances;

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -221,3 +221,16 @@ pub fn set_balance_proposal(value: u64) -> Vec<u8> {
 pub fn set_balance_proposal_hash(value: u64) -> H256 {
     BlakeTwo256::hash(&set_balance_proposal(value)[..])
 }
+
+pub fn add_preimage(hash: H256, does_preimage_updates_jury: bool) {
+    let preimage_status = PreimageStatus::Available {
+        data: set_balance_proposal(4),
+        does_update_jury: does_preimage_updates_jury,
+        provider: ALICE,
+        deposit: 200,
+        since: 1,
+        /// None if it's not imminent.
+        expiry: Some(150),
+    };
+    Preimages::<Runtime>::insert(hash,preimage_status);
+}

--- a/pallets/governance/src/tests.rs
+++ b/pallets/governance/src/tests.rs
@@ -26,6 +26,20 @@ fn update_country_referendum_parameters_when_not_country_owner_does_not_work() {
 }
 
 
+// Creating preimage tests
+#[test]
+fn create_new_preimage_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        let origin = Origin::signed(ALICE);
+        let encoded_proposal = set_balance_proposal(4);
+        assert_ok!(GovernanceModule::note_preimage(origin.clone(), encoded_proposal));
+        assert_eq!(Balances::free_balance(&ALICE), 99987);
+        let hash = set_balance_proposal_hash(4);
+        assert_eq!(last_event(), Event::governance(crate::Event::PreimageNoted(hash, ALICE, 13)));
+    });
+}
+
+
 // Creating proposal tests
 #[test]
 fn create_new_proposal_work() {

--- a/pallets/governance/src/tests.rs
+++ b/pallets/governance/src/tests.rs
@@ -32,6 +32,7 @@ fn create_new_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_eq!(Balances::free_balance(&ALICE), 99400);
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalSubmitted(ALICE, BOB_COUNTRY_ID, 0)));
@@ -43,6 +44,7 @@ fn create_new_proposal_when_not_enough_funds_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600
             , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::InsufficientBalance);
     });
@@ -53,6 +55,7 @@ fn create_new_proposal_when_too_small_deposit_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 40
             , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::DepositTooLow);
     });
@@ -62,6 +65,7 @@ fn create_new_proposal_when_too_small_deposit_does_not_work() {
 fn create_new_proposal_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_noop!(GovernanceModule::propose(Origin::signed(5).clone(), ALICE_COUNTRY_ID, 400
             , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::AccountNotCountryMember);
     });
@@ -72,6 +76,7 @@ fn create_new_proposal_when_queue_full_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         let parameters = ReferendumParameters {
             voting_threshold:  Some(VoteThreshold::RelativeMajority),
             min_proposal_launch_period: 12,
@@ -94,6 +99,7 @@ fn cancel_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID));
         assert_eq!(Balances::free_balance(&ALICE), 100000);
@@ -114,6 +120,7 @@ fn cancel_proposal_that_you_have_not_submitted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::cancel_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::NotProposalCreator);
     });
@@ -124,6 +131,7 @@ fn cancel_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
@@ -137,6 +145,7 @@ fn fast_track_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID));
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalFastTracked(BOB, BOB_COUNTRY_ID, 0)));
@@ -148,6 +157,7 @@ fn fast_track_proposal_when_not_country_owner_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::fast_track_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::AccountNotCountryOwner);
     });
@@ -158,6 +168,7 @@ fn fast_track_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
@@ -171,6 +182,7 @@ fn vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
@@ -184,6 +196,7 @@ fn vote_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), ALICE_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true), Error::<Runtime>::AccountNotCountryMember);
@@ -195,6 +208,7 @@ fn vote_more_than_once_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
@@ -208,6 +222,7 @@ fn remove_vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
@@ -222,6 +237,7 @@ fn remove_vote_when_you_have_not_voted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_remove_vote(Origin::signed(BOB), 0), Error::<Runtime>::AccountHasNotVoted);
@@ -235,16 +251,7 @@ fn emergency_cancel_referendum_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        let preimage_status = PreimageStatus::Available {
-            data: set_balance_proposal(4),
-            does_update_jury: false,
-		    provider: ALICE,
-		    deposit: 200,
-		    since: 1,
-            /// None if it's not imminent.
-            expiry: Some(150),
-        };
-        Preimages::<Runtime>::insert(hash,preimage_status);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(18);
@@ -267,6 +274,8 @@ fn emergency_cancel_referendum_when_not_having_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
+
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(17);
@@ -279,16 +288,7 @@ fn emergency_cancel_referendum_which_removes_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        let preimage_status = PreimageStatus::Available {
-            data: set_balance_proposal(4),
-            does_update_jury: true,
-		    provider: ALICE,
-		    deposit: 200,
-		    since: 1,
-            /// None if it's not imminent.
-            expiry: Some(150),
-        };
-        Preimages::<Runtime>::insert(hash,preimage_status);
+        add_preimage(hash, true);
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(17);
@@ -303,6 +303,7 @@ fn referendum_proposal_passes() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
@@ -318,6 +319,7 @@ fn referendum_proposal_is_rejected() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_eq!(last_event(), Event::governance(crate::Event::ReferendumStarted(0,VoteThreshold::RelativeMajority)));
@@ -335,6 +337,7 @@ fn referendum_proposal_is_enacted() {
         let root = Origin::root();
         let proposer = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(400);
+        add_preimage(hash, false);
         assert_ok!(GovernanceModule::propose(proposer.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));;
         assert_ok!(GovernanceModule::enact_proposal(root.clone(), 0, BOB_COUNTRY_ID));
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalEnacted(BOB_COUNTRY_ID, 0)));

--- a/pallets/governance/src/tests.rs
+++ b/pallets/governance/src/tests.rs
@@ -32,7 +32,7 @@ fn create_new_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_eq!(Balances::free_balance(&ALICE), 99400);
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalSubmitted(ALICE, BOB_COUNTRY_ID, 0)));
     });
@@ -44,7 +44,7 @@ fn create_new_proposal_when_not_enough_funds_does_not_work() {
         let origin = Origin::signed(BOB);
         let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600
-            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(),  PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::InsufficientBalance);
+            , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::InsufficientBalance);
     });
 }
 
@@ -54,7 +54,7 @@ fn create_new_proposal_when_too_small_deposit_does_not_work() {
         let origin = Origin::signed(BOB);
         let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 40
-            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::DepositTooLow);
+            , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::DepositTooLow);
     });
 }
 
@@ -63,7 +63,7 @@ fn create_new_proposal_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(Origin::signed(5).clone(), ALICE_COUNTRY_ID, 400
-            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::AccountNotCountryMember);
+            , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::AccountNotCountryMember);
     });
 }
 
@@ -77,35 +77,16 @@ fn create_new_proposal_when_queue_full_does_not_work() {
             min_proposal_launch_period: 12,
             voting_period:5, 
             enactment_period: 10, 
-            max_params_per_proposal: 2,
             max_proposals_per_country: 0,
         };  
         assert_ok!(GovernanceModule::update_referendum_parameters(origin.clone(), BOB_COUNTRY_ID, parameters));
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 400
-            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::ProposalQueueFull);
+            , hash.clone(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::ProposalQueueFull);
         
     });
 }
 
-#[test]
-fn create_new_proposal_with_too_many_parameters_does_not_work() {
-    ExtBuilder::default().build().execute_with(|| {
-        let origin = Origin::signed(BOB);
-        let hash = set_balance_proposal_hash(4);
-        let parameters = ReferendumParameters {
-            voting_threshold:  Some(VoteThreshold::RelativeMajority),
-            min_proposal_launch_period: 12,
-            voting_period:5, 
-            enactment_period: 10, 
-            max_params_per_proposal: 1,
-            max_proposals_per_country: 1,
-        };  
-        assert_ok!(GovernanceModule::update_referendum_parameters(origin.clone(), BOB_COUNTRY_ID, parameters));
-        assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 400
-            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::TooManyProposalParameters);
-        
-    });
-}
+
 
 // Cancel proposal tests
 #[test]
@@ -113,7 +94,7 @@ fn cancel_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID));
         assert_eq!(Balances::free_balance(&ALICE), 100000);
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalCancelled(ALICE, BOB_COUNTRY_ID, 0)));
@@ -133,7 +114,7 @@ fn cancel_proposal_that_you_have_not_submitted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::cancel_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::NotProposalCreator);
     });
 }
@@ -143,7 +124,7 @@ fn cancel_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
     });
@@ -156,7 +137,7 @@ fn fast_track_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID));
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalFastTracked(BOB, BOB_COUNTRY_ID, 0)));
     });
@@ -167,7 +148,7 @@ fn fast_track_proposal_when_not_country_owner_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::fast_track_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::AccountNotCountryOwner);
     });
 }
@@ -177,7 +158,7 @@ fn fast_track_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(),PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
     });
@@ -190,7 +171,7 @@ fn vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
        // assert_eq!(Balances::free_balance(&BOB), 100);
@@ -203,7 +184,7 @@ fn vote_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), ALICE_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), ALICE_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true), Error::<Runtime>::AccountNotCountryMember);
     });
@@ -214,7 +195,7 @@ fn vote_more_than_once_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         assert_noop!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true), Error::<Runtime>::AccountAlreadyVoted);
@@ -227,7 +208,7 @@ fn remove_vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         assert_ok!(GovernanceModule::try_remove_vote(Origin::signed(BOB), 0));
@@ -241,7 +222,7 @@ fn remove_vote_when_you_have_not_voted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_remove_vote(Origin::signed(BOB), 0), Error::<Runtime>::AccountHasNotVoted);
     });
@@ -254,7 +235,17 @@ fn emergency_cancel_referendum_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let preimage_status = PreimageStatus::Available {
+            data: set_balance_proposal(4),
+            does_update_jury: false,
+		    provider: ALICE,
+		    deposit: 200,
+		    since: 1,
+            /// None if it's not imminent.
+            expiry: Some(150),
+        };
+        Preimages::<Runtime>::insert(hash,preimage_status);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(18);
         assert_ok!(GovernanceModule::emergency_cancel_referendum(origin.clone(), 0));
@@ -276,7 +267,7 @@ fn emergency_cancel_referendum_when_not_having_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(17);
         assert_noop!(GovernanceModule::emergency_cancel_referendum(Origin::signed(BOB), 0), Error::<Runtime>::InsufficientPrivileges);
@@ -288,9 +279,18 @@ fn emergency_cancel_referendum_which_removes_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
+        let preimage_status = PreimageStatus::Available {
+            data: set_balance_proposal(4),
+            does_update_jury: true,
+		    provider: ALICE,
+		    deposit: 200,
+		    since: 1,
+            /// None if it's not imminent.
+            expiry: Some(150),
+        };
+        Preimages::<Runtime>::insert(hash,preimage_status);
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
-        let proposal_parameters = [CountryParameter::SetReferendumJury([1u8;32].into())].to_vec(); //[CountryParameter::SetReferendumJury(BOB)].to_vec();
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), proposal_parameters, PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(17);
         assert_noop!(GovernanceModule::emergency_cancel_referendum(origin.clone(), 0), Error::<Runtime>::InsufficientPrivileges);
     });
@@ -303,7 +303,7 @@ fn referendum_proposal_passes() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         run_to_block(27);
@@ -318,7 +318,7 @@ fn referendum_proposal_is_rejected() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
         let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_eq!(last_event(), Event::governance(crate::Event::ReferendumStarted(0,VoteThreshold::RelativeMajority)));
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, false));
@@ -334,14 +334,9 @@ fn referendum_proposal_is_enacted() {
     ExtBuilder::default().build().execute_with(|| {
         let root = Origin::root();
         let proposer = Origin::signed(ALICE);
-        let hash = set_balance_proposal_hash(4);
-        assert_ok!(GovernanceModule::propose(proposer.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(400);
+        assert_ok!(GovernanceModule::propose(proposer.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_DESCRIPTION.to_vec()));;
         assert_ok!(GovernanceModule::enact_proposal(root.clone(), 0, BOB_COUNTRY_ID));
-        assert_eq!(last_event(), Event::governance(crate::Event::ProposalEnacted(BOB_COUNTRY_ID,0)));
-        let parameters_rec = GovernanceModule::referendum_parameters(BOB_COUNTRY_ID);
-        assert_ne!(parameters_rec, None);
-        let parameters = parameters_rec.unwrap();
-        assert_eq!(parameters.max_proposals_per_country, 2);
-        assert_eq!(parameters.max_params_per_proposal, 2);
+        assert_eq!(last_event(), Event::governance(crate::Event::ProposalEnacted(BOB_COUNTRY_ID, 0)));
     });
 }

--- a/pallets/governance/src/tests.rs
+++ b/pallets/governance/src/tests.rs
@@ -31,7 +31,8 @@ fn update_country_referendum_parameters_when_not_country_owner_does_not_work() {
 fn create_new_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_eq!(Balances::free_balance(&ALICE), 99400);
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalSubmitted(ALICE, BOB_COUNTRY_ID, 0)));
     });
@@ -41,8 +42,9 @@ fn create_new_proposal_work() {
 fn create_new_proposal_when_not_enough_funds_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
+        let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600
-            ,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::InsufficientBalance);
+            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(),  PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::InsufficientBalance);
     });
 }
 
@@ -50,16 +52,18 @@ fn create_new_proposal_when_not_enough_funds_does_not_work() {
 fn create_new_proposal_when_too_small_deposit_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
+        let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 40
-            ,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::DepositTooLow);
+            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::DepositTooLow);
     });
 }
 
 #[test]
 fn create_new_proposal_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
+        let hash = set_balance_proposal_hash(4);
         assert_noop!(GovernanceModule::propose(Origin::signed(5).clone(), ALICE_COUNTRY_ID, 400
-            ,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::AccountNotCountryMember);
+            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::AccountNotCountryMember);
     });
 }
 
@@ -67,6 +71,7 @@ fn create_new_proposal_when_not_country_member_does_not_work() {
 fn create_new_proposal_when_queue_full_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
+        let hash = set_balance_proposal_hash(4);
         let parameters = ReferendumParameters {
             voting_threshold:  Some(VoteThreshold::RelativeMajority),
             min_proposal_launch_period: 12,
@@ -77,7 +82,7 @@ fn create_new_proposal_when_queue_full_does_not_work() {
         };  
         assert_ok!(GovernanceModule::update_referendum_parameters(origin.clone(), BOB_COUNTRY_ID, parameters));
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 400
-            ,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::ProposalQueueFull);
+            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::ProposalQueueFull);
         
     });
 }
@@ -86,6 +91,7 @@ fn create_new_proposal_when_queue_full_does_not_work() {
 fn create_new_proposal_with_too_many_parameters_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(BOB);
+        let hash = set_balance_proposal_hash(4);
         let parameters = ReferendumParameters {
             voting_threshold:  Some(VoteThreshold::RelativeMajority),
             min_proposal_launch_period: 12,
@@ -96,7 +102,7 @@ fn create_new_proposal_with_too_many_parameters_does_not_work() {
         };  
         assert_ok!(GovernanceModule::update_referendum_parameters(origin.clone(), BOB_COUNTRY_ID, parameters));
         assert_noop!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 400
-            ,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::TooManyProposalParameters);
+            , hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()), Error::<Runtime>::TooManyProposalParameters);
         
     });
 }
@@ -106,7 +112,8 @@ fn create_new_proposal_with_too_many_parameters_does_not_work() {
 fn cancel_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID));
         assert_eq!(Balances::free_balance(&ALICE), 100000);
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalCancelled(ALICE, BOB_COUNTRY_ID, 0)));
@@ -125,7 +132,8 @@ fn cancel_non_existing_proposal_does_not_work() {
 fn cancel_proposal_that_you_have_not_submitted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::cancel_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::NotProposalCreator);
     });
 }
@@ -134,7 +142,8 @@ fn cancel_proposal_that_you_have_not_submitted_does_not_work() {
 fn cancel_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::cancel_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
     });
@@ -146,7 +155,8 @@ fn cancel_proposal_that_is_a_referendum_does_not_work() {
 fn fast_track_proposal_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID));
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalFastTracked(BOB, BOB_COUNTRY_ID, 0)));
     });
@@ -156,7 +166,8 @@ fn fast_track_proposal_work() {
 fn fast_track_proposal_when_not_country_owner_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_noop!(GovernanceModule::fast_track_proposal(origin.clone(), 0, BOB_COUNTRY_ID), Error::<Runtime>::AccountNotCountryOwner);
     });
 }
@@ -165,7 +176,8 @@ fn fast_track_proposal_when_not_country_owner_does_not_work() {
 fn fast_track_proposal_that_is_a_referendum_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(),PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::fast_track_proposal(Origin::signed(BOB), 0, BOB_COUNTRY_ID), Error::<Runtime>::ProposalIsReferendum);
     });
@@ -177,7 +189,8 @@ fn fast_track_proposal_that_is_a_referendum_does_not_work() {
 fn vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
        // assert_eq!(Balances::free_balance(&BOB), 100);
@@ -189,7 +202,8 @@ fn vote_work() {
 fn vote_when_not_country_member_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), ALICE_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), ALICE_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true), Error::<Runtime>::AccountNotCountryMember);
     });
@@ -199,7 +213,8 @@ fn vote_when_not_country_member_does_not_work() {
 fn vote_more_than_once_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         assert_noop!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true), Error::<Runtime>::AccountAlreadyVoted);
@@ -211,7 +226,8 @@ fn vote_more_than_once_does_not_work() {
 fn remove_vote_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         assert_ok!(GovernanceModule::try_remove_vote(Origin::signed(BOB), 0));
@@ -224,7 +240,8 @@ fn remove_vote_work() {
 fn remove_vote_when_you_have_not_voted_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_noop!(GovernanceModule::try_remove_vote(Origin::signed(BOB), 0), Error::<Runtime>::AccountHasNotVoted);
     });
@@ -236,7 +253,8 @@ fn remove_vote_when_you_have_not_voted_does_not_work() {
 fn emergency_cancel_referendum_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(18);
         assert_ok!(GovernanceModule::emergency_cancel_referendum(origin.clone(), 0));
@@ -257,7 +275,8 @@ fn emergency_cancel_non_existing_referendum_does_not_work() {
 fn emergency_cancel_referendum_when_not_having_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         run_to_block(17);
         assert_noop!(GovernanceModule::emergency_cancel_referendum(Origin::signed(BOB), 0), Error::<Runtime>::InsufficientPrivileges);
@@ -268,9 +287,10 @@ fn emergency_cancel_referendum_when_not_having_privileges_does_not_work() {
 fn emergency_cancel_referendum_which_removes_privileges_does_not_work() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
+        let hash = set_balance_proposal_hash(4);
         ReferendumJuryOf::<Runtime>::insert(BOB_COUNTRY_ID,ALICE);
         let proposal_parameters = [CountryParameter::SetReferendumJury([1u8;32].into())].to_vec(); //[CountryParameter::SetReferendumJury(BOB)].to_vec();
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, proposal_parameters, PROPOSAL_DESCRIPTION.to_vec()));
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), proposal_parameters, PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(17);
         assert_noop!(GovernanceModule::emergency_cancel_referendum(origin.clone(), 0), Error::<Runtime>::InsufficientPrivileges);
     });
@@ -282,7 +302,8 @@ fn emergency_cancel_referendum_which_removes_privileges_does_not_work() {
 fn referendum_proposal_passes() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, true));
         run_to_block(27);
@@ -296,7 +317,8 @@ fn referendum_proposal_passes() {
 fn referendum_proposal_is_rejected() {
     ExtBuilder::default().build().execute_with(|| {
         let origin = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600,PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(origin.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         run_to_block(16);
         assert_eq!(last_event(), Event::governance(crate::Event::ReferendumStarted(0,VoteThreshold::RelativeMajority)));
         assert_ok!(GovernanceModule::try_vote(Origin::signed(BOB), 0, false));
@@ -312,7 +334,8 @@ fn referendum_proposal_is_enacted() {
     ExtBuilder::default().build().execute_with(|| {
         let root = Origin::root();
         let proposer = Origin::signed(ALICE);
-        assert_ok!(GovernanceModule::propose(proposer.clone(), BOB_COUNTRY_ID, 600, PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
+        let hash = set_balance_proposal_hash(4);
+        assert_ok!(GovernanceModule::propose(proposer.clone(), BOB_COUNTRY_ID, 600, hash.clone(), PROPOSAL_PARAMETERS.to_vec(), PROPOSAL_DESCRIPTION.to_vec()));
         assert_ok!(GovernanceModule::enact_proposal(root.clone(), 0, BOB_COUNTRY_ID));
         assert_eq!(last_event(), Event::governance(crate::Event::ProposalEnacted(BOB_COUNTRY_ID,0)));
         let parameters_rec = GovernanceModule::referendum_parameters(BOB_COUNTRY_ID);

--- a/pallets/governance/src/types.rs
+++ b/pallets/governance/src/types.rs
@@ -44,7 +44,6 @@ pub enum VoteThreshold {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub enum CountryParameter {
     MaxProposals(u8),
-    MaxParametersPerProposal(u8),
     SetReferendumJury(AccountId),
 }
 

--- a/pallets/governance/src/types.rs
+++ b/pallets/governance/src/types.rs
@@ -1,8 +1,35 @@
 use codec::{Encode, Decode};
-use sp_runtime::{RuntimeDebug, traits::One};
+use sp_runtime::{RuntimeDebug, traits::{One,Hash}};
 use sp_std::vec::Vec;
 use primitives::{CountryId, ProposalId, ReferendumId,AccountId};
 use crate::*;
+
+
+#[derive(Clone, Encode, Decode, RuntimeDebug)]
+pub enum PreimageStatus<AccountId, Balance, BlockNumber> {
+	/// The preimage is imminently needed at the argument.
+	Missing(BlockNumber),
+	/// The preimage is available.
+	Available {
+		data: Vec<u8>,
+		provider: AccountId,
+		deposit: Balance,
+		since: BlockNumber,
+		/// None if it's not imminent.
+		expiry: Option<BlockNumber>,
+	},
+}
+
+impl<AccountId, Balance, BlockNumber> PreimageStatus<AccountId, Balance, BlockNumber> {
+	fn to_missing_expiry(self) -> Option<BlockNumber> {
+		match self {
+			PreimageStatus::Missing(expiry) => Some(expiry),
+			_ => None,
+		}
+	}
+}
+
+
 
 #[derive(Encode, Decode,  Clone, PartialEq, Eq, RuntimeDebug)]
 pub enum VoteThreshold {
@@ -97,9 +124,10 @@ pub struct VotingRecord {
 
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
-pub struct ProposalInfo<AccountId,BlockNumber,CountryParameter> {
+pub struct ProposalInfo<AccountId,BlockNumber,CountryParameter,Hash> {
     pub(crate) proposed_by: AccountId,
     pub(crate) parameters: Vec<CountryParameter>,
+    pub(crate) hash: Hash,
     pub(crate) description: Vec<u8>, // link to proposal description
     pub(crate) referendum_launch_block: BlockNumber,
 }

--- a/pallets/governance/src/types.rs
+++ b/pallets/governance/src/types.rs
@@ -12,6 +12,7 @@ pub enum PreimageStatus<AccountId, Balance, BlockNumber> {
 	/// The preimage is available.
 	Available {
 		data: Vec<u8>,
+        does_update_jury: bool,
 		provider: AccountId,
 		deposit: Balance,
 		since: BlockNumber,
@@ -53,7 +54,7 @@ pub struct ReferendumParameters<BlockNumber> {
     pub(crate) min_proposal_launch_period: BlockNumber,// number of blocks
     pub(crate) voting_period: BlockNumber, // number of block
     pub(crate) enactment_period: BlockNumber, // number of blocks
-    pub(crate) max_params_per_proposal: u8,
+    //pub(crate) max_params_per_proposal: u8,
     pub(crate) max_proposals_per_country: u8,
 }
 /*
@@ -64,7 +65,7 @@ impl<BlockNumber: From<u32> + Default> Default for ReferendumParameters<BlockNum
             min_proposal_launch_period: T::Pallet::DefaultProposalLaunchPeriod::get(),
             voting_period:  T::DefaultVotingPeriod::get(), 
             enactment_period:  T::DefaultEnactmentPeriod::get(), 
-            max_params_per_proposal:  T::DefaultMaxParametersPerProposal::get(),
+          //  max_params_per_proposal:  T::DefaultMaxParametersPerProposal::get(),
             max_proposals_per_country: T::DefaultMaxProposalsPerCountry::get(),
         }
     }
@@ -124,9 +125,9 @@ pub struct VotingRecord {
 
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
-pub struct ProposalInfo<AccountId,BlockNumber,CountryParameter,Hash> {
+pub struct ProposalInfo<AccountId,BlockNumber,Hash> {
     pub(crate) proposed_by: AccountId,
-    pub(crate) parameters: Vec<CountryParameter>,
+    //pub(crate) parameter: CountryParameter,
     pub(crate) hash: Hash,
     pub(crate) description: Vec<u8>, // link to proposal description
     pub(crate) referendum_launch_block: BlockNumber,

--- a/pallets/governance/src/types.rs
+++ b/pallets/governance/src/types.rs
@@ -53,7 +53,6 @@ pub struct ReferendumParameters<BlockNumber> {
     pub(crate) min_proposal_launch_period: BlockNumber,// number of blocks
     pub(crate) voting_period: BlockNumber, // number of block
     pub(crate) enactment_period: BlockNumber, // number of blocks
-    //pub(crate) max_params_per_proposal: u8,
     pub(crate) max_proposals_per_country: u8,
 }
 /*
@@ -126,7 +125,6 @@ pub struct VotingRecord {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub struct ProposalInfo<AccountId,BlockNumber,Hash> {
     pub(crate) proposed_by: AccountId,
-    //pub(crate) parameter: CountryParameter,
     pub(crate) hash: Hash,
     pub(crate) description: Vec<u8>, // link to proposal description
     pub(crate) referendum_launch_block: BlockNumber,

--- a/runtime/bitcountry/src/lib.rs
+++ b/runtime/bitcountry/src/lib.rs
@@ -1137,6 +1137,7 @@ parameter_types! {
     pub const DefaultMaxProposalsPerCountry: u8 = 4; //Default 4 parameters
     pub const OneBlock: BlockNumber = 1;
     pub const MinimumProposalDeposit: Balance = 10 * DOLLARS;
+    pub const DefaultPreimageByteDeposit: Balance = 1 * DOLLARS;
 }
 
 impl governance::Config for Runtime {
@@ -1146,6 +1147,7 @@ impl governance::Config for Runtime {
     type DefaultMaxParametersPerProposal =  DefaultMaxParametersPerProposal;
     type DefaultMaxProposalsPerCountry = DefaultMaxProposalsPerCountry;
     type MinimumProposalDeposit = MinimumProposalDeposit;
+    type DefaultPreimageByteDeposit = DefaultPreimageByteDeposit;
     type OneBlock = OneBlock;
     type Event = Event;
     type Currency = Balances;


### PR DESCRIPTION
Updated the Bit.Country local governance so now it uses preimages instead of passing a list of parameters.
Currently, there are 2 more things that need to be implemented

- function that checks  whether a preimage contains only calls that are within the scope of the local governance
- function that checks if a preimage proposes country jury member and  updates the preimage status so the jury address cannot cancel the proposal